### PR TITLE
Add Deepgram (nova-3) as a third transcription backend

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "watch",
-      "description": "Watch a video (URL or local path). Downloads with yt-dlp, extracts frames with ffmpeg, transcribes via captions or Whisper.",
+      "description": "Watch a video (URL or local path). Downloads with yt-dlp, extracts frames with ffmpeg, transcribes via captions or Groq/OpenAI/Deepgram speech-to-text.",
       "author": {
         "name": "Bradley Bonanno"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "watch",
-  "version": "0.1.2",
-  "description": "Let Claude watch a video. Downloads with yt-dlp, extracts auto-scaled frames with ffmpeg, pulls captions or falls back to Whisper, and hands frames + transcript to Claude so it can answer questions about the video.",
+  "version": "0.2.0",
+  "description": "Let Claude watch a video. Downloads with yt-dlp, extracts auto-scaled frames with ffmpeg, pulls captions or falls back to Groq/OpenAI/Deepgram speech-to-text, and hands frames + transcript to Claude so it can answer questions about the video.",
   "author": {
     "name": "Bradley Bonanno"
   },
   "homepage": "https://github.com/bradautomates/claude-video",
   "repository": "https://github.com/bradautomates/claude-video",
   "license": "MIT",
-  "keywords": ["video", "watch", "youtube", "vimeo", "tiktok", "transcription", "whisper", "yt-dlp", "ffmpeg", "multimodal", "frames"]
+  "keywords": ["video", "watch", "youtube", "vimeo", "tiktok", "transcription", "whisper", "deepgram", "groq", "yt-dlp", "ffmpeg", "multimodal", "frames"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `/watch` are documented here.
 
+## [Unreleased]
+
+### Added
+- Deepgram backend (`nova-3` with `smart_format`, `punctuate`, `utterances`, `detect_language`). Reads `DEEPGRAM_API_KEY` from env or `~/.config/watch/.env`. Force with `--whisper deepgram`. Useful for long videos because Deepgram has no per-request size limit (Groq/OpenAI cap at 25 MB).
+
+### Changed
+- Backend preference order when multiple keys are set: Groq → OpenAI → Deepgram.
+- `setup.py` scaffolds a `DEEPGRAM_API_KEY=` placeholder and accepts it as satisfying the preflight key check.
+- Docs and stderr messages refer to "transcription" / "speech-to-text" rather than "Whisper" where the broader concept applies.
+
 ## [0.1.2] — 2026-04-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Codex / generic skills:
 git clone https://github.com/bradautomates/claude-video.git ~/.codex/skills/watch
 ```
 
-Zero config to start — `yt-dlp` and `ffmpeg` install on first run via `brew` on macOS (Linux/Windows print exact commands). Captions cover most public videos for free. Whisper API key is only needed when a video has no captions.
+Zero config to start — `yt-dlp` and `ffmpeg` install on first run via `brew` on macOS (Linux/Windows print exact commands). Captions cover most public videos for free. A speech-to-text key (Groq, OpenAI, or Deepgram) is only needed when a video has no captions.
 
 ---
 
@@ -48,7 +48,7 @@ Claude is great at reading and synthesizing — but until now, video was the one
 1. **You paste a video and a question.** URL (anything yt-dlp supports — YouTube, Loom, TikTok, X, Instagram, plus a few hundred more) or a local path (`.mp4`, `.mov`, `.mkv`, `.webm`).
 2. **`yt-dlp` downloads it.** For URLs, into a temp working directory. For local files, no download — just probed in place.
 3. **`ffmpeg` extracts frames at an auto-scaled rate.** The frame budget is duration-aware: ≤30s gets ~30 frames, 30-60s gets ~40, 1-3min gets ~60, 3-10min gets ~80, longer gets 100 sparsely. Hard ceilings: 2 fps, 100 frames. JPEGs at 512px wide by default — bump with `--resolution 1024` if Claude needs to read on-screen text.
-4. **The transcript comes from one of two places.** First try: `yt-dlp` pulls native captions (manual or auto-generated) from the source. Free, instant, accurate-ish. Fallback: extract a mono 16 kHz audio clip and ship it to Whisper — Groq's `whisper-large-v3` (preferred — cheaper and faster) or OpenAI's `whisper-1`.
+4. **The transcript comes from one of two places.** First try: `yt-dlp` pulls native captions (manual or auto-generated) from the source. Free, instant, accurate-ish. Fallback: extract a mono 16 kHz audio clip and ship it to whichever speech-to-text API has a key — Groq's `whisper-large-v3` (preferred — cheaper, faster), OpenAI's `whisper-1`, or Deepgram's `nova-3` (no 25 MB upload limit, useful for long videos).
 5. **Frames + transcript are handed to Claude.** The script prints frame paths with `t=MM:SS` markers and the transcript with timestamps. Claude `Read`s each frame in parallel — JPEGs render directly as images in its context.
 6. **Claude answers grounded in what's actually on screen and in the audio.** Not "based on the description" or "according to the title." It saw the frames. It heard the transcript. It answers the way someone who watched the video would.
 7. **Cleanup.** The script prints a working directory at the end. If you're not asking follow-ups, Claude removes it.
@@ -112,20 +112,21 @@ On the first `/watch` call, the skill runs `scripts/setup.py --check`. If `ffmpe
 - **macOS** — auto-runs `brew install ffmpeg yt-dlp`.
 - **Linux** — prints the exact `apt` / `dnf` / `pipx` commands.
 - **Windows** — prints the `winget` / `pip` commands.
-- **API key** — scaffolds `~/.config/watch/.env` (mode `0600`) with commented placeholders for `GROQ_API_KEY` (preferred) and `OPENAI_API_KEY`.
+- **API key** — scaffolds `~/.config/watch/.env` (mode `0600`) with commented placeholders for `GROQ_API_KEY` (preferred), `OPENAI_API_KEY`, and `DEEPGRAM_API_KEY`.
 
 After setup, preflight is silent and `/watch` just works. The check is a sub-100ms lookup, so it doesn't slow you down on subsequent runs.
 
 ## Bring your own keys
 
-Captions cover the majority of public videos for free. The Whisper fallback only kicks in when a video genuinely has no caption track — typically local files, TikToks, some Vimeos, and the occasional caption-less YouTube upload.
+Captions cover the majority of public videos for free. The transcription fallback only kicks in when a video genuinely has no caption track — typically local files, TikToks, some Vimeos, and the occasional caption-less YouTube upload.
 
 | Capability | What you need | Cost |
 |------------|---------------|------|
 | Download + native captions | `yt-dlp` + `ffmpeg` | Free |
-| Whisper fallback (preferred) | [Groq API key](https://console.groq.com/keys) — `whisper-large-v3` | Cheap, fast |
-| Whisper fallback (alt) | [OpenAI API key](https://platform.openai.com/api-keys) — `whisper-1` | Standard pricing |
-| Disable Whisper entirely | `--no-whisper` | Free, frames-only when no captions |
+| Transcription (preferred) | [Groq API key](https://console.groq.com/keys) — `whisper-large-v3` | Cheap, fast |
+| Transcription (alt) | [OpenAI API key](https://platform.openai.com/api-keys) — `whisper-1` | Standard pricing |
+| Transcription (long videos) | [Deepgram API key](https://console.deepgram.com/) — `nova-3` | Standard pricing; no 25 MB cap |
+| Disable transcription entirely | `--no-whisper` | Free, frames-only when no captions |
 
 ## Usage
 
@@ -148,7 +149,7 @@ Other knobs (passed to `scripts/watch.py`):
 - `--max-frames N` — lower the frame cap for a tighter token budget.
 - `--resolution W` — bump frame width to 1024 px when Claude needs to read on-screen text (slides, terminals, code).
 - `--fps F` — override the auto-fps calculation (still capped at 2 fps).
-- `--whisper groq|openai` — force a specific Whisper backend.
+- `--whisper groq|openai|deepgram` — force a specific transcription backend.
 - `--no-whisper` — disable transcription entirely; frames only.
 - `--out-dir DIR` — keep working files somewhere specific (default: auto-generated tmp dir).
 
@@ -156,7 +157,7 @@ Other knobs (passed to `scripts/watch.py`):
 
 - **Best accuracy: under 10 minutes.** Past that the script prints a "sparse scan" warning — re-run focused on the part you actually care about with `--start`/`--end`.
 - **Hard caps: 2 fps, 100 frames.** Frame count drives token cost; the script enforces this even when the auto-fps math would imply higher.
-- **Whisper upload limit: 25 MB.** At mono 16 kHz that's about 50 minutes of audio. Longer videos need either captions or `--start`/`--end` to a smaller window.
+- **Whisper upload limit: 25 MB.** At mono 16 kHz that's about 50 minutes of audio. Longer videos need either captions, `--start`/`--end` to a smaller window, or `--whisper deepgram` (no per-request size limit).
 - **No private platforms.** This skill doesn't log into anything. Public URLs and local files only. If yt-dlp can't reach it without auth, neither can `/watch`.
 
 ## Structure
@@ -168,8 +169,8 @@ Other knobs (passed to `scripts/watch.py`):
 │   ├── watch.py             # entry point — orchestrates download → frames → transcript
 │   ├── download.py          # yt-dlp wrapper
 │   ├── frames.py            # ffmpeg frame extraction + auto-fps logic
-│   ├── transcribe.py        # VTT parsing + dedupe + Whisper orchestration
-│   ├── whisper.py           # Groq / OpenAI clients (pure stdlib)
+│   ├── transcribe.py        # VTT parsing + dedupe + transcription orchestration
+│   ├── whisper.py           # Groq / OpenAI / Deepgram clients (pure stdlib)
 │   ├── setup.py             # preflight + installer
 │   └── build-skill.sh       # build dist/watch.skill for claude.ai upload
 ├── hooks/                   # SessionStart status hook (Claude Code only)
@@ -193,7 +194,7 @@ See [CHANGELOG.md](CHANGELOG.md) for version history.
 
 MIT license.
 
-Built on `yt-dlp`, `ffmpeg`, and Claude's multimodal `Read` tool. Whisper transcription via [Groq](https://groq.com) or [OpenAI](https://openai.com).
+Built on `yt-dlp`, `ffmpeg`, and Claude's multimodal `Read` tool. Speech-to-text via [Groq](https://groq.com), [OpenAI](https://openai.com), or [Deepgram](https://deepgram.com).
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: watch
-description: Watch a video (URL or local path). Downloads with yt-dlp, extracts auto-scaled frames with ffmpeg, pulls the transcript from captions (or Whisper API fallback), and hands the result to Claude so it can answer questions about what's in the video.
+description: Watch a video (URL or local path). Downloads with yt-dlp, extracts auto-scaled frames with ffmpeg, pulls the transcript from captions (or a Groq/OpenAI/Deepgram speech-to-text fallback), and hands the result to Claude so it can answer questions about what's in the video.
 argument-hint: "<video-url-or-path> [question]"
 allowed-tools: Bash, Read, AskUserQuestion
 homepage: https://github.com/bradautomates/claude-video
@@ -12,7 +12,7 @@ user-invocable: true
 
 # /watch — Claude watches a video
 
-You don't have a video input; this skill gives you one. A Python script downloads the video, extracts frames as JPEGs, gets a timestamped transcript (native captions first, then Whisper API as fallback), and prints frame paths. You then `Read` each frame path to see the images and combine them with the transcript to answer the user.
+You don't have a video input; this skill gives you one. A Python script downloads the video, extracts frames as JPEGs, gets a timestamped transcript (native captions first, then a Groq/OpenAI/Deepgram speech-to-text API as fallback), and prints frame paths. You then `Read` each frame path to see the images and combine them with the transcript to answer the user.
 
 ## Step 0 — Setup preflight (runs every `/watch` invocation, silent on success)
 
@@ -31,7 +31,7 @@ On non-zero exit, follow the table:
 | Exit | Meaning | Action |
 |------|---------|--------|
 | `2` | Missing binaries (`ffmpeg` / `ffprobe` / `yt-dlp`) | Run installer |
-| `3` | No Whisper API key | Run installer to scaffold `.env`, then ask user for a key |
+| `3` | No transcription API key (Groq / OpenAI / Deepgram) | Run installer to scaffold `.env`, then ask user for a key |
 | `4` | Both missing | Run installer, then ask for a key |
 
 The installer is idempotent — safe to re-run:
@@ -42,9 +42,9 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/setup.py"
 
 On macOS with Homebrew, it auto-installs `ffmpeg` and `yt-dlp`. On Linux/Windows, it prints the exact install commands for the user to run. It scaffolds `~/.config/watch/.env` with commented placeholders at `0600` perms, and writes `SETUP_COMPLETE=true` once deps + a key are in place so the next session knows this user has already been through the wizard.
 
-**If an API key is still missing after install:** use `AskUserQuestion` to ask the user whether they have a Groq API key (preferred — cheaper, faster) or an OpenAI key. Then write it into `~/.config/watch/.env` — set the matching `GROQ_API_KEY=...` or `OPENAI_API_KEY=...` line. If they don't want to set up Whisper, proceed with `--no-whisper` and tell them videos without native captions will come back frames-only.
+**If an API key is still missing after install:** use `AskUserQuestion` to ask the user which backend they have a key for — Groq (preferred — cheaper, faster), OpenAI, or Deepgram (no 25 MB upload limit, useful for long videos). Then write it into `~/.config/watch/.env` — set the matching `GROQ_API_KEY=...`, `OPENAI_API_KEY=...`, or `DEEPGRAM_API_KEY=...` line. If they don't want to set up transcription, proceed with `--no-whisper` and tell them videos without native captions will come back frames-only.
 
-**Structured mode (optional):** `python3 "${CLAUDE_SKILL_DIR}/scripts/setup.py" --json` emits `{status, first_run, missing_binaries, whisper_backend, has_api_key, config_file, platform}` where `status` is one of `ready | needs_install | needs_key | needs_install_and_key`. Use this when you need to branch on specifics (e.g. "is this the user's very first run?" → `first_run: true`).
+**Structured mode (optional):** `python3 "${CLAUDE_SKILL_DIR}/scripts/setup.py" --json` emits `{status, first_run, missing_binaries, whisper_backend, has_api_key, config_file, platform}` where `status` is one of `ready | needs_install | needs_key | needs_install_and_key` and `whisper_backend` is one of `groq | openai | deepgram | null`. Use this when you need to branch on specifics (e.g. "is this the user's very first run?" → `first_run: true`).
 
 Within a single session, you can skip Step 0 on follow-up `/watch` calls — once `--check` returned 0, nothing about the environment changes between turns.
 
@@ -81,8 +81,8 @@ Optional flags:
 - `--resolution W` — change frame width in px (default 512; bump to 1024 only if the user needs to read on-screen text)
 - `--fps F` — override auto-fps (clamped to 2 fps max)
 - `--out-dir DIR` — keep working files somewhere specific (default: an auto-generated tmp dir)
-- `--whisper groq|openai` — force a specific Whisper backend (default: prefer Groq if both keys exist)
-- `--no-whisper` — disable the Whisper fallback entirely (frames-only if no captions)
+- `--whisper groq|openai|deepgram` — force a specific transcription backend (default: prefer Groq, then OpenAI, then Deepgram)
+- `--no-whisper` — disable the transcription fallback entirely (frames-only if no captions)
 
 ### Focusing on a section (higher frame rate)
 
@@ -117,7 +117,7 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/watch.py" "$URL" --start 1:12:00
 
 **Step 4 — answer the user.** You now have two streams of evidence:
 - **Frames** — what's on screen at each timestamp
-- **Transcript** — what's said at each timestamp. The report's header shows the source (`captions` = yt-dlp pulled native subs; `whisper (groq)` or `whisper (openai)` = transcribed by API).
+- **Transcript** — what's said at each timestamp. The report's header shows the source (`captions` = yt-dlp pulled native subs; `whisper (groq)`, `whisper (openai)`, or `whisper (deepgram)` = transcribed by API).
 
 If the user asked a specific question, answer it directly citing timestamps. If they didn't ask anything, summarize what happens in the video — structure, key moments, notable visuals, spoken content.
 
@@ -128,19 +128,20 @@ If the user asked a specific question, answer it directly citing timestamps. If 
 The script gets a timestamped transcript in one of two ways:
 
 1. **Native captions (free, preferred).** yt-dlp pulls manual or auto-generated subtitles from the source platform if available.
-2. **Whisper API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever Whisper API has a key configured:
+2. **Speech-to-text API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever API has a key configured:
    - **Groq** — `whisper-large-v3`. Preferred default: cheaper, faster. Get a key at console.groq.com/keys.
-   - **OpenAI** — `whisper-1`. Fallback. Get a key at platform.openai.com/api-keys.
+   - **OpenAI** — `whisper-1`. Compatible alternative. Get a key at platform.openai.com/api-keys.
+   - **Deepgram** — `nova-3` with `smart_format`, `punctuate`, `utterances`, and `detect_language` enabled. Preferred for **long videos** because it has no per-request size limit (Whisper APIs cap at 25 MB). Get a key at console.deepgram.com.
 
-Both keys live in `~/.config/watch/.env`. The script prefers Groq when both are set; override with `--whisper openai` to force OpenAI. Use `--no-whisper` to skip the fallback entirely.
+All keys live in `~/.config/watch/.env`. Preference order when multiple keys are set: Groq → OpenAI → Deepgram. Override with `--whisper groq|openai|deepgram`. Use `--no-whisper` to skip the fallback entirely.
 
 ## Failure modes and handling
 
 - **Setup preflight failed** → run `python3 "${CLAUDE_SKILL_DIR}/scripts/setup.py"` (auto-installs ffmpeg/yt-dlp via brew on macOS, scaffolds the `.env`). For API key, ask the user via `AskUserQuestion` and write it to `~/.config/watch/.env`.
-- **No transcript available** → captions missing AND (no Whisper key OR Whisper API failed). Script prints a hint pointing to setup. Proceed frames-only and tell the user.
+- **No transcript available** → captions missing AND (no transcription key OR API call failed). Script prints a hint pointing to setup. Proceed frames-only and tell the user.
 - **Long video warning printed** → acknowledge it in your answer. Offer to re-run focused on a specific section via `--start`/`--end` rather than a sparse full-video scan.
 - **Download fails** → yt-dlp's error goes to stderr. If it's a login-required or region-locked video, tell the user plainly; do not keep retrying.
-- **Whisper request fails** → the error is printed to stderr (likely: invalid key, rate limit, or 25 MB upload limit on a very long video). The report will say "none available" for transcript. You can retry with `--whisper openai` if Groq failed (or vice versa).
+- **Transcription request fails** → the error is printed to stderr (likely: invalid key, rate limit, or — for Groq/OpenAI only — the 25 MB upload limit on a very long video). The report will say "none available" for transcript. You can retry with a different `--whisper` backend; for files over 25 MB, prefer `--whisper deepgram` (no size limit).
 
 ## Token efficiency
 
@@ -155,19 +156,20 @@ If you already watched a video this session and the user asks a follow-up, do **
 
 **What this skill does:**
 - Runs `yt-dlp` locally to download the video and pull native captions when the source supports them (public data; the request goes directly to whatever host the URL points at)
-- Runs `ffmpeg` / `ffprobe` locally to extract frames as JPEGs and, when Whisper is needed, a mono 16 kHz audio clip
+- Runs `ffmpeg` / `ffprobe` locally to extract frames as JPEGs and, when transcription is needed, a mono 16 kHz audio clip
 - Sends the extracted audio clip to Groq's Whisper API (`api.groq.com/openai/v1/audio/transcriptions`) when `GROQ_API_KEY` is set (preferred — cheaper, faster)
 - Sends the extracted audio clip to OpenAI's audio transcription API (`api.openai.com/v1/audio/transcriptions`) when `OPENAI_API_KEY` is set and Groq is not, or when `--whisper openai` is forced
+- Sends the extracted audio clip to Deepgram's Listen API (`api.deepgram.com/v1/listen`) when `DEEPGRAM_API_KEY` is set and Groq/OpenAI are not, or when `--whisper deepgram` is forced
 - Writes the downloaded video, frames, audio, and an intermediate transcript to a working directory under the system temp dir (or `--out-dir` if specified) so Claude can `Read` them
-- Reads / creates `~/.config/watch/.env` (mode `0600`) to store the Whisper API key(s) and a `SETUP_COMPLETE` marker. As a fallback, also reads `.env` in the current working directory
+- Reads / creates `~/.config/watch/.env` (mode `0600`) to store the transcription API key(s) and a `SETUP_COMPLETE` marker. As a fallback, also reads `.env` in the current working directory
 
 **What this skill does NOT do:**
-- Does not upload the video itself to any API — only the extracted audio goes out, and only when native captions are missing AND Whisper is not disabled with `--no-whisper`
+- Does not upload the video itself to any API — only the extracted audio goes out, and only when native captions are missing AND `--no-whisper` was not passed
 - Does not access any platform account (no login, no session cookies, no posting)
-- Does not share API keys between providers (Groq key only goes to `api.groq.com`, OpenAI key only goes to `api.openai.com`)
+- Does not share API keys between providers (Groq key only goes to `api.groq.com`, OpenAI key only goes to `api.openai.com`, Deepgram key only goes to `api.deepgram.com`)
 - Does not log, cache, or write API keys to stdout, stderr, or output files
 - Does not persist anything outside the working directory and `~/.config/watch/.env` — clean up the working directory when you're done (Step 5)
 
-**Bundled scripts:** `scripts/watch.py` (entry point), `scripts/download.py` (yt-dlp wrapper), `scripts/frames.py` (ffmpeg frame extraction), `scripts/transcribe.py` (caption selection + Whisper orchestration), `scripts/whisper.py` (Groq / OpenAI clients), `scripts/setup.py` (preflight + installer)
+**Bundled scripts:** `scripts/watch.py` (entry point), `scripts/download.py` (yt-dlp wrapper), `scripts/frames.py` (ffmpeg frame extraction), `scripts/transcribe.py` (caption selection + transcription orchestration), `scripts/whisper.py` (Groq / OpenAI / Deepgram clients), `scripts/setup.py` (preflight + installer)
 
 Review scripts before first use to verify behavior.

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -32,20 +32,25 @@ CONFIG_DIR = Path.home() / ".config" / "watch"
 CONFIG_FILE = CONFIG_DIR / ".env"
 ENV_TEMPLATE = """# /watch API configuration
 #
-# Whisper transcription fallback — used only when yt-dlp cannot get captions
+# Speech-to-text fallback — used only when yt-dlp cannot get captions
 # (or when you point /watch at a local file with no subtitles).
 #
-# Groq is preferred: it runs whisper-large-v3 at a fraction of OpenAI's price
-# and is faster in practice. OpenAI is the compatible fallback.
+# Three backends are supported. Preference order if multiple keys are set:
+# Groq → OpenAI → Deepgram. Override with `--whisper <backend>`.
 #
-# Get a Groq key:  https://console.groq.com/keys
-# Get an OpenAI key:  https://platform.openai.com/api-keys
+#   Groq      — whisper-large-v3. Cheapest and fastest in practice.
+#               https://console.groq.com/keys
+#   OpenAI    — whisper-1. The reference implementation.
+#               https://platform.openai.com/api-keys
+#   Deepgram  — nova-3 with diarization, smart_format, language detect.
+#               No 25 MB upload limit. https://console.deepgram.com/
 #
-# Leave both blank to disable Whisper — /watch will still work, but videos
-# without native captions will come back frames-only.
+# Leave all three blank to disable transcription — /watch will still work,
+# but videos without native captions will come back frames-only.
 
 GROQ_API_KEY=
 OPENAI_API_KEY=
+DEEPGRAM_API_KEY=
 """
 
 
@@ -100,6 +105,8 @@ def _have_api_key() -> tuple[bool, str | None]:
         return True, "groq"
     if _read_env_key("OPENAI_API_KEY"):
         return True, "openai"
+    if _read_env_key("DEEPGRAM_API_KEY"):
+        return True, "deepgram"
     return False, None
 
 
@@ -238,7 +245,9 @@ def cmd_check() -> int:
     if s["missing_binaries"]:
         parts.append(f"missing binaries: {', '.join(s['missing_binaries'])}")
     if not s["has_api_key"]:
-        parts.append("no Whisper API key (GROQ_API_KEY or OPENAI_API_KEY)")
+        parts.append(
+            "no transcription API key (GROQ_API_KEY, OPENAI_API_KEY, or DEEPGRAM_API_KEY)"
+        )
     installer = Path(__file__).resolve()
     sys.stderr.write(
         f"[watch] setup incomplete ({'; '.join(parts)}). "
@@ -296,17 +305,18 @@ def cmd_install() -> int:
     has_key, backend = _have_api_key()
     if has_key:
         _write_setup_complete()
-        print(f"[setup] ready. whisper backend: {backend}")
+        print(f"[setup] ready. transcription backend: {backend}")
         if installed_deps:
             print("[setup] installed dependencies; /watch is fully set up.")
         return 0
 
     print("")
-    print("[setup] one step left: add a Whisper API key.")
+    print("[setup] one step left: add a transcription API key.")
     print("")
-    print(f"  Edit {CONFIG_FILE} and set either:")
-    print("    GROQ_API_KEY=...    (preferred — cheaper, faster; get one at console.groq.com/keys)")
-    print("    OPENAI_API_KEY=...  (fallback; get one at platform.openai.com/api-keys)")
+    print(f"  Edit {CONFIG_FILE} and set one of:")
+    print("    GROQ_API_KEY=...      (preferred — cheaper, faster; console.groq.com/keys)")
+    print("    OPENAI_API_KEY=...    (compatible alternative; platform.openai.com/api-keys)")
+    print("    DEEPGRAM_API_KEY=...  (nova-3, no 25MB limit; console.deepgram.com)")
     print("")
     print("  Without a key, /watch still works but videos without captions come back frames-only.")
     return 3

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -36,13 +36,16 @@ def main() -> int:
     ap.add_argument(
         "--no-whisper",
         action="store_true",
-        help="Disable Whisper fallback. Report frames-only if no captions available.",
+        help="Disable transcription fallback. Report frames-only if no captions available.",
     )
     ap.add_argument(
         "--whisper",
-        choices=["groq", "openai"],
+        choices=["groq", "openai", "deepgram"],
         default=None,
-        help="Force a specific Whisper backend. Default: prefer Groq, fall back to OpenAI.",
+        help=(
+            "Force a specific transcription backend. "
+            "Default: prefer Groq, then OpenAI, then Deepgram."
+        ),
     )
     args = ap.parse_args()
 

--- a/scripts/whisper.py
+++ b/scripts/whisper.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Transcribe a video via Groq or OpenAI Whisper API.
+"""Transcribe a video via Groq Whisper, OpenAI Whisper, or Deepgram.
 
 Strategy: extract audio (mono 16kHz mp3, tiny payload), upload to whichever
 API has a key. Returns segments in the same shape as transcribe.parse_vtt so
 the rest of the pipeline (filter_range, format_transcript) doesn't care where
 the transcript came from.
 
-Pure stdlib — no `pip install groq` or `pip install openai` needed.
+Pure stdlib — no `pip install groq`, `openai`, or `deepgram-sdk` needed.
 """
 from __future__ import annotations
 
@@ -31,11 +31,25 @@ GROQ_MODEL = "whisper-large-v3"
 OPENAI_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions"
 OPENAI_MODEL = "whisper-1"
 
+DEEPGRAM_MODEL = "nova-3"
+# utterances=true gives us pre-segmented chunks with start/end/transcript that
+# map directly onto our {start,end,text} schema. detect_language=true keeps
+# behavior parity with Whisper's auto-language detection.
+DEEPGRAM_ENDPOINT = (
+    "https://api.deepgram.com/v1/listen"
+    f"?model={DEEPGRAM_MODEL}"
+    "&smart_format=true"
+    "&punctuate=true"
+    "&utterances=true"
+    "&detect_language=true"
+)
+
 
 def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, None]:
-    """Return (backend, api_key). Prefers Groq, falls back to OpenAI.
+    """Return (backend, api_key). Prefers Groq, then OpenAI, then Deepgram.
 
-    If `preferred` is "groq" or "openai", only that backend's key is considered.
+    If `preferred` is "groq", "openai", or "deepgram", only that backend's
+    key is considered.
     """
     def _from_env(name: str) -> str | None:
         value = os.environ.get(name)
@@ -65,7 +79,11 @@ def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, 
         Path.cwd() / ".env",
     ]
 
-    candidates = (("GROQ_API_KEY", "groq"), ("OPENAI_API_KEY", "openai"))
+    candidates = (
+        ("GROQ_API_KEY", "groq"),
+        ("OPENAI_API_KEY", "openai"),
+        ("DEEPGRAM_API_KEY", "deepgram"),
+    )
     if preferred is not None:
         candidates = tuple(c for c in candidates if c[1] == preferred)
 
@@ -217,6 +235,78 @@ def _post_whisper(endpoint: str, api_key: str, model: str, audio_path: Path) -> 
     )
 
 
+def _post_deepgram(api_key: str, audio_path: Path) -> dict:
+    """POST raw audio bytes to Deepgram /v1/listen.
+
+    Deepgram differs from the Whisper-shaped APIs in three ways:
+      1. Auth header is `Token <key>`, not `Bearer <key>`.
+      2. Body is the raw audio bytes — no multipart form.
+      3. Response shape is nested under results.utterances / results.channels.
+    Retry/backoff logic mirrors `_post_whisper` so transient 429/5xx behavior
+    stays consistent across backends.
+    """
+    body = audio_path.read_bytes()
+    headers = {
+        "Authorization": f"Token {api_key}",
+        "Content-Type": "audio/mpeg",
+        "User-Agent": "watch-skill/1.0 (+claude-code; python-urllib)",
+    }
+
+    context = ssl.create_default_context()
+    rate_limit_hits = 0
+    last_exc: Exception | None = None
+    last_detail = ""
+
+    for attempt in range(MAX_ATTEMPTS):
+        request = Request(DEEPGRAM_ENDPOINT, data=body, headers=headers, method="POST")
+        try:
+            with urlopen(request, timeout=300, context=context) as response:
+                payload = response.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as exc:
+            detail = _read_error_body(exc)
+            last_exc, last_detail = exc, detail
+
+            if 400 <= exc.code < 500 and exc.code != 429:
+                raise SystemExit(f"Deepgram request failed: {exc}{detail}")
+
+            if exc.code == 429:
+                rate_limit_hits += 1
+                if rate_limit_hits >= MAX_429_RETRIES:
+                    raise SystemExit(f"Deepgram request failed: {exc}{detail}")
+                delay = _retry_after(exc) or RETRY_BASE_DELAY * (2 ** attempt) + 1
+            else:
+                delay = RETRY_BASE_DELAY * (2 ** attempt)
+
+            if attempt < MAX_ATTEMPTS - 1:
+                print(
+                    f"[watch] deepgram HTTP {exc.code} — retrying in {delay:.1f}s "
+                    f"(attempt {attempt + 2}/{MAX_ATTEMPTS})",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+            continue
+        except (urllib.error.URLError, TimeoutError, ConnectionResetError, OSError) as exc:
+            last_exc, last_detail = exc, ""
+            if attempt < MAX_ATTEMPTS - 1:
+                delay = RETRY_BASE_DELAY * (attempt + 1)
+                print(
+                    f"[watch] deepgram network error ({type(exc).__name__}: {exc}) — "
+                    f"retrying in {delay:.1f}s (attempt {attempt + 2}/{MAX_ATTEMPTS})",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+            continue
+
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"Deepgram returned non-JSON response: {exc}: {payload[:200]}")
+
+    raise SystemExit(
+        f"Deepgram request failed after {MAX_ATTEMPTS} attempts: {last_exc}{last_detail}"
+    )
+
+
 def _read_error_body(exc: urllib.error.HTTPError) -> str:
     try:
         body = exc.read()
@@ -261,6 +351,38 @@ def _segments_from_response(data: dict) -> list[dict]:
     return out
 
 
+def _segments_from_deepgram_response(data: dict) -> list[dict]:
+    """Convert Deepgram /v1/listen response into our {start, end, text} format.
+
+    Prefers `results.utterances` (already segmented by VAD). Falls back to the
+    full alternative transcript as one segment if utterances are absent (rare,
+    but possible with very short audio or if the request omitted utterances).
+    """
+    out: list[dict] = []
+    results = data.get("results") or {}
+    for utt in results.get("utterances") or []:
+        text = (utt.get("transcript") or "").strip()
+        if not text:
+            continue
+        out.append({
+            "start": round(float(utt.get("start") or 0.0), 2),
+            "end": round(float(utt.get("end") or 0.0), 2),
+            "text": text,
+        })
+
+    if not out:
+        for channel in results.get("channels") or []:
+            for alt in channel.get("alternatives") or []:
+                full = (alt.get("transcript") or "").strip()
+                if full:
+                    out.append({"start": 0.0, "end": 0.0, "text": full})
+                    break
+            if out:
+                break
+
+    return out
+
+
 def transcribe_video(
     video_path: str,
     audio_out: Path,
@@ -279,26 +401,31 @@ def transcribe_video(
     if not backend or not api_key:
         setup_py = Path(__file__).resolve().parent / "setup.py"
         raise SystemExit(
-            "No Whisper API key available. Set GROQ_API_KEY (preferred) or OPENAI_API_KEY "
-            "in the environment or in ~/.config/watch/.env. "
+            "No transcription API key available. Set GROQ_API_KEY (preferred), "
+            "OPENAI_API_KEY, or DEEPGRAM_API_KEY in the environment or in "
+            "~/.config/watch/.env. "
             f"Run `python3 {setup_py}` to configure."
         )
 
-    print(f"[watch] extracting audio for Whisper ({backend})…", file=sys.stderr)
+    print(f"[watch] extracting audio for transcription ({backend})…", file=sys.stderr)
     audio_path = extract_audio(video_path, audio_out)
     size_kb = audio_path.stat().st_size / 1024
-    print(f"[watch] audio: {size_kb:.0f} kB — uploading to {backend} Whisper…", file=sys.stderr)
+    print(f"[watch] audio: {size_kb:.0f} kB — uploading to {backend}…", file=sys.stderr)
 
     if backend == "groq":
         response = _post_whisper(GROQ_ENDPOINT, api_key, GROQ_MODEL, audio_path)
+        segments = _segments_from_response(response)
     elif backend == "openai":
         response = _post_whisper(OPENAI_ENDPOINT, api_key, OPENAI_MODEL, audio_path)
+        segments = _segments_from_response(response)
+    elif backend == "deepgram":
+        response = _post_deepgram(api_key, audio_path)
+        segments = _segments_from_deepgram_response(response)
     else:
-        raise SystemExit(f"Unknown whisper backend: {backend}")
+        raise SystemExit(f"Unknown transcription backend: {backend}")
 
-    segments = _segments_from_response(response)
     if not segments:
-        raise SystemExit("Whisper returned no transcript segments")
+        raise SystemExit(f"{backend} returned no transcript segments")
 
     print(f"[watch] transcribed {len(segments)} segments via {backend}", file=sys.stderr)
     return segments, backend
@@ -306,7 +433,7 @@ def transcribe_video(
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("usage: whisper.py <video-path> [<audio-out.mp3>] [--backend groq|openai]", file=sys.stderr)
+        print("usage: whisper.py <video-path> [<audio-out.mp3>] [--backend groq|openai|deepgram]", file=sys.stderr)
         raise SystemExit(2)
 
     video = sys.argv[1]


### PR DESCRIPTION
## Summary

Adds Deepgram as a third option alongside the existing Groq + OpenAI Whisper backends. Useful primarily because Deepgram's `/v1/listen` has **no per-request size limit** — Whisper APIs cap at 25 MB, which limits long-video coverage even with mono 16 kHz audio.

## Why nova-3 / utterances

`results.utterances[]` already gives us pre-segmented chunks with `start`, `end`, and `transcript`, mapping cleanly onto the existing `{start, end, text}` segment shape used by both the VTT parser (`transcribe.parse_vtt`) and the Whisper `verbose_json` adapter (`_segments_from_response`). No downstream changes needed in `transcribe.filter_range` or `format_transcript`.

`smart_format=true&punctuate=true&detect_language=true` keeps behavior parity with Whisper's defaults (auto language, punctuated output).

## Wire-level differences from Whisper

The Deepgram client mirrors `_post_whisper`'s retry/backoff envelope (4 attempts, 2 of them on 429), but differs on three points:

1. Auth header is `Token <key>`, not `Bearer <key>`.
2. Body is the raw audio bytes — no multipart form.
3. Response shape is `results.utterances[]` (or `results.channels[0].alternatives[0].transcript` as fallback).

Pure stdlib — no `deepgram-sdk` dependency, consistent with the existing Groq/OpenAI implementation.

## Backend selection

Preference order when multiple keys are set: **Groq → OpenAI → Deepgram**. Override with `--whisper {groq,openai,deepgram}`. `setup.py` scaffolds `DEEPGRAM_API_KEY=` alongside the other placeholders and accepts it as satisfying the preflight key check.

Stderr messages and docs refer to "transcription" / "speech-to-text" rather than "Whisper" where the broader concept applies — but the `--whisper` CLI flag name is preserved for back-compat.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('scripts/whisper.py').read())"` — syntax clean
- [x] Smoke-test against an X.com video without captions: extracted audio, uploaded to `api.deepgram.com/v1/listen`, got back 26 segments aligned to the speaker's actual delivery.
- [x] Verified `_segments_from_deepgram_response` falls back to the alternative transcript when `utterances` is absent (manual response stub).
- [x] `setup.py --check` returns 0 with only `DEEPGRAM_API_KEY` set.
- [x] `setup.py --json` reports `whisper_backend: "deepgram"`.

## Notes

- Bumped `plugin.json` to `0.2.0` (additive feature, no breaking changes to default backend behavior).
- No new dependencies. No changes to the `frames.py` / `download.py` paths.