### PR TITLE
Fix two Windows install issues (UTF-8 console + pip yt-dlp on PATH)

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -50,7 +50,24 @@ OPENAI_API_KEY=
 
 
 def _which(name: str) -> str | None:
-    return shutil.which(name)
+    hit = shutil.which(name)
+    if hit:
+        return hit
+    # Windows fallback: pip may have installed yt-dlp.exe in a user Scripts
+    # directory that isn't on PATH. Probe the importable module before
+    # declaring it missing — otherwise the installer's `pip install yt-dlp`
+    # hint is a no-op for users who already have it.
+    if name == "yt-dlp":
+        try:
+            r = subprocess.run(
+                [sys.executable, "-m", "yt_dlp", "--version"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if r.returncode == 0:
+                return f"{sys.executable} -m yt_dlp"
+        except Exception:
+            pass
+    return None
 
 
 def _check_binaries() -> list[str]:

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -11,6 +11,12 @@ import sys
 import tempfile
 from pathlib import Path
 
+# Force UTF-8 on stdout/stderr so the unicode characters in the report
+# (e.g. "→", "…") don't crash on Windows consoles that default to cp1252.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR))


### PR DESCRIPTION
## Summary

Two surgical fixes for Windows users hitting the skill cold:

1. **`scripts/watch.py` crashes immediately on the markdown report** because Python on Windows defaults to cp1252 on stdout, and the report emits `→` (and `…` elsewhere). I hit this on a fresh install — first `/watch` call exits with `UnicodeEncodeError: 'charmap' codec can't encode character '\u2192'`. Fix: `sys.stdout.reconfigure(encoding=\"utf-8\", errors=\"replace\")` at module top.

2. **`setup.py --check` reports yt-dlp as missing even when it's installed via pip.** On Windows, `pip install yt-dlp` puts `yt-dlp.exe` into `%APPDATA%\Python\Python<ver>\Scripts\` — that directory is NOT on PATH for git-bash sessions by default, so `shutil.which(\"yt-dlp\")` returns None. The installer then prints `pip install --user yt-dlp` as the fix, which is a no-op for these users.

Fix: `_which(\"yt-dlp\")` now falls back to probing `python -m yt_dlp --version` before returning None. If the module is importable, treat the binary as available. Same pattern applies for any pip-installed CLI; I scoped the fallback to `yt-dlp` only to keep the change minimal.

## Test plan

- [x] On Windows 11 + Python 3.14 + git-bash, fresh install: `python scripts/watch.py "$URL" --no-whisper --start 0 --end 30 --max-frames 6` previously crashed on the report header → now runs end-to-end clean.
- [x] `python scripts/setup.py --check` previously returned exit 2 (missing binaries) with yt-dlp pip-installed but not on PATH → now returns exit 0 (or exit 3 if no Whisper key, which is the expected next-step error).
- [x] No behavior change on macOS/Linux: `shutil.which` hits on the first line, fallback never runs.
- [x] No behavior change for the `ffmpeg` / `ffprobe` checks — fallback is gated to `name == \"yt-dlp\"`.

Happy to split into two PRs if you'd prefer one-fix-per-PR.