### PR TITLE
Add ElevenLabs Scribe as preferred transcription backend

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -128,11 +128,12 @@ If the user asked a specific question, answer it directly citing timestamps. If 
 The script gets a timestamped transcript in one of two ways:
 
 1. **Native captions (free, preferred).** yt-dlp pulls manual or auto-generated subtitles from the source platform if available.
-2. **Whisper API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever Whisper API has a key configured:
-   - **Groq** — `whisper-large-v3`. Preferred default: cheaper, faster. Get a key at console.groq.com/keys.
+2. **Speech-to-Text API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever transcription API has a key configured:
+   - **ElevenLabs** — `scribe_v1`. Preferred default: highest accuracy, word-level timestamps. Get a key at elevenlabs.io/app/settings/api-keys.
+   - **Groq** — `whisper-large-v3`. Fallback. Get a key at console.groq.com/keys.
    - **OpenAI** — `whisper-1`. Fallback. Get a key at platform.openai.com/api-keys.
 
-Both keys live in `~/.config/watch/.env`. The script prefers Groq when both are set; override with `--whisper openai` to force OpenAI. Use `--no-whisper` to skip the fallback entirely.
+Keys live in `~/.config/watch/.env`. Order of preference: ElevenLabs → Groq → OpenAI. Override with `--whisper elevenlabs|groq|openai`. Use `--no-whisper` to skip the fallback entirely.
 
 ## Failure modes and handling
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -32,18 +32,20 @@ CONFIG_DIR = Path.home() / ".config" / "watch"
 CONFIG_FILE = CONFIG_DIR / ".env"
 ENV_TEMPLATE = """# /watch API configuration
 #
-# Whisper transcription fallback — used only when yt-dlp cannot get captions
+# Transcription fallback — used only when yt-dlp cannot get captions
 # (or when you point /watch at a local file with no subtitles).
 #
-# Groq is preferred: it runs whisper-large-v3 at a fraction of OpenAI's price
-# and is faster in practice. OpenAI is the compatible fallback.
+# ElevenLabs Scribe is preferred (highest accuracy). Groq whisper-large-v3
+# and OpenAI whisper-1 are compatible fallbacks.
 #
-# Get a Groq key:  https://console.groq.com/keys
-# Get an OpenAI key:  https://platform.openai.com/api-keys
+# Get an ElevenLabs key:  https://elevenlabs.io/app/settings/api-keys
+# Get a Groq key:         https://console.groq.com/keys
+# Get an OpenAI key:      https://platform.openai.com/api-keys
 #
-# Leave both blank to disable Whisper — /watch will still work, but videos
-# without native captions will come back frames-only.
+# Leave all blank to disable transcription — /watch will still work, but
+# videos without native captions will come back frames-only.
 
+ELEVENLABS_API_KEY=
 GROQ_API_KEY=
 OPENAI_API_KEY=
 """
@@ -96,6 +98,8 @@ def _read_env_key(name: str) -> str | None:
 
 
 def _have_api_key() -> tuple[bool, str | None]:
+    if _read_env_key("ELEVENLABS_API_KEY"):
+        return True, "elevenlabs"
     if _read_env_key("GROQ_API_KEY"):
         return True, "groq"
     if _read_env_key("OPENAI_API_KEY"):

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -40,9 +40,9 @@ def main() -> int:
     )
     ap.add_argument(
         "--whisper",
-        choices=["groq", "openai"],
+        choices=["elevenlabs", "groq", "openai"],
         default=None,
-        help="Force a specific Whisper backend. Default: prefer Groq, fall back to OpenAI.",
+        help="Force a specific transcription backend. Default: prefer ElevenLabs, then Groq, then OpenAI.",
     )
     args = ap.parse_args()
 

--- a/scripts/whisper.py
+++ b/scripts/whisper.py
@@ -31,11 +31,14 @@ GROQ_MODEL = "whisper-large-v3"
 OPENAI_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions"
 OPENAI_MODEL = "whisper-1"
 
+ELEVENLABS_ENDPOINT = "https://api.elevenlabs.io/v1/speech-to-text"
+ELEVENLABS_MODEL = "scribe_v1"
+
 
 def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, None]:
-    """Return (backend, api_key). Prefers Groq, falls back to OpenAI.
+    """Return (backend, api_key). Prefers ElevenLabs, then Groq, then OpenAI.
 
-    If `preferred` is "groq" or "openai", only that backend's key is considered.
+    If `preferred` is "elevenlabs", "groq", or "openai", only that backend's key is considered.
     """
     def _from_env(name: str) -> str | None:
         value = os.environ.get(name)
@@ -65,7 +68,11 @@ def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, 
         Path.cwd() / ".env",
     ]
 
-    candidates = (("GROQ_API_KEY", "groq"), ("OPENAI_API_KEY", "openai"))
+    candidates = (
+        ("ELEVENLABS_API_KEY", "elevenlabs"),
+        ("GROQ_API_KEY", "groq"),
+        ("OPENAI_API_KEY", "openai"),
+    )
     if preferred is not None:
         candidates = tuple(c for c in candidates if c[1] == preferred)
 
@@ -240,6 +247,123 @@ def _retry_after(exc: urllib.error.HTTPError) -> float | None:
         return None
 
 
+def _post_elevenlabs(api_key: str, audio_path: Path) -> dict:
+    fields = {
+        "model_id": ELEVENLABS_MODEL,
+        "timestamps_granularity": "word",
+    }
+    body, boundary = _build_multipart(fields, audio_path)
+    headers = {
+        "xi-api-key": api_key,
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
+        "User-Agent": "watch-skill/1.0 (+claude-code; python-urllib)",
+    }
+
+    context = ssl.create_default_context()
+    rate_limit_hits = 0
+    last_exc: Exception | None = None
+    last_detail = ""
+
+    for attempt in range(MAX_ATTEMPTS):
+        request = Request(ELEVENLABS_ENDPOINT, data=body, headers=headers, method="POST")
+        try:
+            with urlopen(request, timeout=300, context=context) as response:
+                payload = response.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as exc:
+            detail = _read_error_body(exc)
+            last_exc, last_detail = exc, detail
+            if 400 <= exc.code < 500 and exc.code != 429:
+                raise SystemExit(f"ElevenLabs request failed: {exc}{detail}")
+            if exc.code == 429:
+                rate_limit_hits += 1
+                if rate_limit_hits >= MAX_429_RETRIES:
+                    raise SystemExit(f"ElevenLabs request failed: {exc}{detail}")
+                delay = _retry_after(exc) or RETRY_BASE_DELAY * (2 ** attempt) + 1
+            else:
+                delay = RETRY_BASE_DELAY * (2 ** attempt)
+            if attempt < MAX_ATTEMPTS - 1:
+                print(
+                    f"[watch] elevenlabs HTTP {exc.code} — retrying in {delay:.1f}s "
+                    f"(attempt {attempt + 2}/{MAX_ATTEMPTS})",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+            continue
+        except (urllib.error.URLError, TimeoutError, ConnectionResetError, OSError) as exc:
+            last_exc, last_detail = exc, ""
+            if attempt < MAX_ATTEMPTS - 1:
+                delay = RETRY_BASE_DELAY * (attempt + 1)
+                print(
+                    f"[watch] elevenlabs network error ({type(exc).__name__}: {exc}) — "
+                    f"retrying in {delay:.1f}s (attempt {attempt + 2}/{MAX_ATTEMPTS})",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+            continue
+
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"ElevenLabs returned non-JSON response: {exc}: {payload[:200]}")
+
+    raise SystemExit(
+        f"ElevenLabs request failed after {MAX_ATTEMPTS} attempts: {last_exc}{last_detail}"
+    )
+
+
+def _segments_from_elevenlabs(data: dict, max_segment_seconds: float = 8.0) -> list[dict]:
+    """Group ElevenLabs word-level output into ~8s segments.
+
+    Response shape: {"text": str, "words": [{"text", "start", "end", "type"}], ...}
+    """
+    words = data.get("words") or []
+    out: list[dict] = []
+    cur_start: float | None = None
+    cur_end: float = 0.0
+    cur_words: list[str] = []
+
+    def _flush() -> None:
+        if cur_words and cur_start is not None:
+            text = "".join(cur_words).strip()
+            if text:
+                out.append({
+                    "start": round(cur_start, 2),
+                    "end": round(cur_end, 2),
+                    "text": text,
+                })
+
+    for w in words:
+        wtype = w.get("type") or "word"
+        wtext = w.get("text") or ""
+        wstart = float(w.get("start") or 0.0)
+        wend = float(w.get("end") or wstart)
+
+        if wtype == "spacing":
+            cur_words.append(wtext)
+            cur_end = wend or cur_end
+            continue
+
+        if cur_start is None:
+            cur_start = wstart
+        cur_words.append(wtext)
+        cur_end = wend
+        ends_sentence = wtext.rstrip().endswith((".", "!", "?"))
+        if (cur_end - cur_start) >= max_segment_seconds or ends_sentence:
+            _flush()
+            cur_start = None
+            cur_end = 0.0
+            cur_words = []
+
+    _flush()
+
+    if not out:
+        full = (data.get("text") or "").strip()
+        if full:
+            out.append({"start": 0.0, "end": 0.0, "text": full})
+
+    return out
+
+
 def _segments_from_response(data: dict) -> list[dict]:
     """Convert Whisper verbose_json into our {start, end, text} segment format."""
     out: list[dict] = []
@@ -279,26 +403,30 @@ def transcribe_video(
     if not backend or not api_key:
         setup_py = Path(__file__).resolve().parent / "setup.py"
         raise SystemExit(
-            "No Whisper API key available. Set GROQ_API_KEY (preferred) or OPENAI_API_KEY "
-            "in the environment or in ~/.config/watch/.env. "
+            "No transcription API key available. Set ELEVENLABS_API_KEY (preferred), "
+            "GROQ_API_KEY, or OPENAI_API_KEY in the environment or in ~/.config/watch/.env. "
             f"Run `python3 {setup_py}` to configure."
         )
 
-    print(f"[watch] extracting audio for Whisper ({backend})…", file=sys.stderr)
+    print(f"[watch] extracting audio for transcription ({backend})…", file=sys.stderr)
     audio_path = extract_audio(video_path, audio_out)
     size_kb = audio_path.stat().st_size / 1024
-    print(f"[watch] audio: {size_kb:.0f} kB — uploading to {backend} Whisper…", file=sys.stderr)
+    print(f"[watch] audio: {size_kb:.0f} kB — uploading to {backend}…", file=sys.stderr)
 
-    if backend == "groq":
+    if backend == "elevenlabs":
+        response = _post_elevenlabs(api_key, audio_path)
+        segments = _segments_from_elevenlabs(response)
+    elif backend == "groq":
         response = _post_whisper(GROQ_ENDPOINT, api_key, GROQ_MODEL, audio_path)
+        segments = _segments_from_response(response)
     elif backend == "openai":
         response = _post_whisper(OPENAI_ENDPOINT, api_key, OPENAI_MODEL, audio_path)
+        segments = _segments_from_response(response)
     else:
-        raise SystemExit(f"Unknown whisper backend: {backend}")
+        raise SystemExit(f"Unknown transcription backend: {backend}")
 
-    segments = _segments_from_response(response)
     if not segments:
-        raise SystemExit("Whisper returned no transcript segments")
+        raise SystemExit(f"{backend} returned no transcript segments")
 
     print(f"[watch] transcribed {len(segments)} segments via {backend}", file=sys.stderr)
     return segments, backend


### PR DESCRIPTION
## Summary

- Adds ElevenLabs Scribe (`scribe_v1`) as the preferred Speech-to-Text backend in the `/watch` skill, ahead of Groq and OpenAI Whisper.
- Word-level timestamps from Scribe are grouped into ~8 second segments at sentence boundaries to match the existing `{start, end, text}` segment shape.
- Existing Groq / OpenAI Whisper paths are unchanged — they remain as fallbacks.

## Why

ElevenLabs Scribe gives word-level timestamps and higher accuracy than `whisper-large-v3` / `whisper-1`, with comparable cost. Users with an ElevenLabs account paying for Scribe credits previously had no way to plug it into `/watch`.

## What changed

- `scripts/whisper.py`
  - New constants `ELEVENLABS_ENDPOINT`, `ELEVENLABS_MODEL`.
  - `load_api_key` checks `ELEVENLABS_API_KEY` first, then `GROQ_API_KEY`, then `OPENAI_API_KEY`.
  - New `_post_elevenlabs` (auth via `xi-api-key`, same retry / 429 logic as the Whisper path).
  - New `_segments_from_elevenlabs` groups word-level output into ~8s segments, flushing on sentence-ending punctuation.
  - `transcribe_video` dispatches per backend.
- `scripts/watch.py`
  - `--whisper` argparse choices now `elevenlabs|groq|openai`.
- `scripts/setup.py`
  - `ENV_TEMPLATE` includes `ELEVENLABS_API_KEY` placeholder + key URL comment.
  - `_have_api_key` checks ElevenLabs first.
- `SKILL.md`
  - Documents the new preference order and `--whisper elevenlabs` override.

## Reviewer notes

- The flag stays named `--whisper` for backwards compatibility, even though the backends are no longer all Whisper-family. Happy to rename to `--stt` / `--transcribe` if you prefer.
- Segment grouping for Scribe is a heuristic (8s window or sentence end). Open to a smarter chunker if you have one in mind.
- No new dependencies — pure stdlib `urllib` + multipart, same as the existing Whisper path.

## Test plan

- [ ] `python scripts/setup.py --json` reports `whisper_backend: "elevenlabs"` when only `ELEVENLABS_API_KEY` is set.
- [ ] `/watch <local-mp4>` with no native captions transcribes via ElevenLabs and produces timestamped segments.
- [ ] `/watch <url> --whisper groq` still routes to Groq when both keys are set.
- [ ] `/watch <url> --no-whisper` still skips transcription entirely.