### PR TITLE
feat: add AssemblyAI as a third transcription backend (v0.2.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "watch",
-  "version": "0.1.3",
-  "description": "Let Claude watch a video. Downloads with yt-dlp, extracts auto-scaled frames with ffmpeg, pulls captions or falls back to Whisper, and hands frames + transcript to Claude so it can answer questions about the video.",
+  "version": "0.2.0",
+  "description": "Let Claude watch a video. Downloads with yt-dlp, extracts auto-scaled frames with ffmpeg, pulls captions or transcribes via Groq/AssemblyAI/OpenAI, and hands frames + transcript to Claude so it can answer questions about the video.",
   "author": {
     "name": "Bradley Bonanno"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `/watch` are documented here.
 
+## [0.2.0] — 2026-05-09
+
+### Added
+- **AssemblyAI backend** as a third transcription option. Async client (upload → create job → poll up to 30 min) wired into `whisper.py`. Set `ASSEMBLYAI_API_KEY` in `~/.config/watch/.env` or env, or force with `--whisper assemblyai`. Pricing sits between Groq (~$0.04/h) and OpenAI (~$0.36/h) at ~$0.27/h, with strong PT-BR support and a much higher upload size ceiling than Groq/OpenAI's 25 MB.
+
+### Changed
+- Auto-priority for transcription is now cost-ascending: **Groq → AssemblyAI → OpenAI**. Users with only Groq or only OpenAI configured see no behavior change. Users with multiple keys configured will pick the cheapest available.
+- `setup.py` env template, `--check` error message, and installer prompts updated to mention all three backends.
+- `SKILL.md` and the privacy section list AssemblyAI alongside Groq and OpenAI.
+
 ## [0.1.3] — 2026-05-09
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -42,7 +42,7 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/setup.py"
 
 On macOS with Homebrew, it auto-installs `ffmpeg` and `yt-dlp`. On Linux/Windows, it prints the exact install commands for the user to run. It scaffolds `~/.config/watch/.env` with commented placeholders at `0600` perms, and writes `SETUP_COMPLETE=true` once deps + a key are in place so the next session knows this user has already been through the wizard.
 
-**If an API key is still missing after install:** use `AskUserQuestion` to ask the user whether they have a Groq API key (preferred — cheaper, faster) or an OpenAI key. Then write it into `~/.config/watch/.env` — set the matching `GROQ_API_KEY=...` or `OPENAI_API_KEY=...` line. If they don't want to set up Whisper, proceed with `--no-whisper` and tell them videos without native captions will come back frames-only.
+**If an API key is still missing after install:** use `AskUserQuestion` to ask the user which transcription backend they want — Groq (cheapest, ~$0.04/h), AssemblyAI (~$0.27/h, strong PT-BR), or OpenAI (~$0.36/h). Then write it into `~/.config/watch/.env` — set the matching `GROQ_API_KEY=...`, `ASSEMBLYAI_API_KEY=...`, or `OPENAI_API_KEY=...` line. If they don't want to set up transcription, proceed with `--no-whisper` and tell them videos without native captions will come back frames-only.
 
 **Structured mode (optional):** `python3 "${CLAUDE_SKILL_DIR}/scripts/setup.py" --json` emits `{status, first_run, missing_binaries, whisper_backend, has_api_key, config_file, platform}` where `status` is one of `ready | needs_install | needs_key | needs_install_and_key`. Use this when you need to branch on specifics (e.g. "is this the user's very first run?" → `first_run: true`).
 
@@ -81,8 +81,8 @@ Optional flags:
 - `--resolution W` — change frame width in px (default 512; bump to 1024 only if the user needs to read on-screen text)
 - `--fps F` — override auto-fps (clamped to 2 fps max)
 - `--out-dir DIR` — keep working files somewhere specific (default: an auto-generated tmp dir)
-- `--whisper groq|openai` — force a specific Whisper backend (default: prefer Groq if both keys exist)
-- `--no-whisper` — disable the Whisper fallback entirely (frames-only if no captions)
+- `--whisper groq|assemblyai|openai` — force a specific transcription backend (default priority cost-ascending: Groq → AssemblyAI → OpenAI)
+- `--no-whisper` — disable the transcription fallback entirely (frames-only if no captions)
 
 ### Focusing on a section (higher frame rate)
 
@@ -128,19 +128,20 @@ If the user asked a specific question, answer it directly citing timestamps. If 
 The script gets a timestamped transcript in one of two ways:
 
 1. **Native captions (free, preferred).** yt-dlp pulls manual or auto-generated subtitles from the source platform if available.
-2. **Whisper API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever Whisper API has a key configured:
-   - **Groq** — `whisper-large-v3`. Preferred default: cheaper, faster. Get a key at console.groq.com/keys.
-   - **OpenAI** — `whisper-1`. Fallback. Get a key at platform.openai.com/api-keys.
+2. **Transcription API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever backend has a key configured:
+   - **Groq** — `whisper-large-v3`, ~$0.04/h. Single-shot multipart upload. Default priority. Get a key at console.groq.com/keys.
+   - **AssemblyAI** — Universal model, ~$0.27/h. Async (upload → create job → poll up to 30 min). Strong PT-BR + auto language detection. Get a key at assemblyai.com/dashboard/signup.
+   - **OpenAI** — `whisper-1`, ~$0.36/h. Single-shot multipart upload. Get a key at platform.openai.com/api-keys.
 
-Both keys live in `~/.config/watch/.env`. The script prefers Groq when both are set; override with `--whisper openai` to force OpenAI. Use `--no-whisper` to skip the fallback entirely.
+Keys live in `~/.config/watch/.env`. Auto-priority is cost-ascending (Groq → AssemblyAI → OpenAI) when multiple are set; override with `--whisper assemblyai` (etc.) to force one. Use `--no-whisper` to skip the fallback entirely.
 
 ## Failure modes and handling
 
 - **Setup preflight failed** → run `python3 "${CLAUDE_SKILL_DIR}/scripts/setup.py"` (auto-installs ffmpeg/yt-dlp via brew on macOS, scaffolds the `.env`). For API key, ask the user via `AskUserQuestion` and write it to `~/.config/watch/.env`.
-- **No transcript available** → captions missing AND (no Whisper key OR Whisper API failed). Script prints a hint pointing to setup. Proceed frames-only and tell the user.
+- **No transcript available** → captions missing AND (no transcription key OR all backends failed). Script prints a hint pointing to setup. Proceed frames-only and tell the user.
 - **Long video warning printed** → acknowledge it in your answer. Offer to re-run focused on a specific section via `--start`/`--end` rather than a sparse full-video scan.
 - **Download fails** → yt-dlp's error goes to stderr. If it's a login-required or region-locked video, tell the user plainly; do not keep retrying.
-- **Whisper request fails** → the error is printed to stderr (likely: invalid key, rate limit, or 25 MB upload limit on a very long video). The report will say "none available" for transcript. You can retry with `--whisper openai` if Groq failed (or vice versa).
+- **Transcription request fails** → the error is printed to stderr (likely: invalid key, rate limit, or 25 MB upload limit on Groq/OpenAI for very long videos — AssemblyAI accepts much larger). The report will say "none available" for transcript. You can retry with another backend via `--whisper assemblyai` / `--whisper openai` / `--whisper groq` if the first failed.
 
 ## Token efficiency
 
@@ -155,19 +156,20 @@ If you already watched a video this session and the user asks a follow-up, do **
 
 **What this skill does:**
 - Runs `yt-dlp` locally to download the video and pull native captions when the source supports them (public data; the request goes directly to whatever host the URL points at)
-- Runs `ffmpeg` / `ffprobe` locally to extract frames as JPEGs and, when Whisper is needed, a mono 16 kHz audio clip
-- Sends the extracted audio clip to Groq's Whisper API (`api.groq.com/openai/v1/audio/transcriptions`) when `GROQ_API_KEY` is set (preferred — cheaper, faster)
-- Sends the extracted audio clip to OpenAI's audio transcription API (`api.openai.com/v1/audio/transcriptions`) when `OPENAI_API_KEY` is set and Groq is not, or when `--whisper openai` is forced
+- Runs `ffmpeg` / `ffprobe` locally to extract frames as JPEGs and, when transcription is needed, a mono 16 kHz audio clip
+- Sends the extracted audio clip to Groq's Whisper API (`api.groq.com/openai/v1/audio/transcriptions`) when `GROQ_API_KEY` is set (default priority — cheapest)
+- Sends the extracted audio clip to AssemblyAI (`api.assemblyai.com/v2/upload` then `/v2/transcript`) when `ASSEMBLYAI_API_KEY` is set and Groq is not, or when `--whisper assemblyai` is forced
+- Sends the extracted audio clip to OpenAI's audio transcription API (`api.openai.com/v1/audio/transcriptions`) when `OPENAI_API_KEY` is set and the higher-priority keys aren't, or when `--whisper openai` is forced
 - Writes the downloaded video, frames, audio, and an intermediate transcript to a working directory under the system temp dir (or `--out-dir` if specified) so Claude can `Read` them
-- Reads / creates `~/.config/watch/.env` (mode `0600`) to store the Whisper API key(s) and a `SETUP_COMPLETE` marker. As a fallback, also reads `.env` in the current working directory
+- Reads / creates `~/.config/watch/.env` (mode `0600`) to store the transcription API key(s) and a `SETUP_COMPLETE` marker. As a fallback, also reads `.env` in the current working directory
 
 **What this skill does NOT do:**
 - Does not upload the video itself to any API — only the extracted audio goes out, and only when native captions are missing AND Whisper is not disabled with `--no-whisper`
 - Does not access any platform account (no login, no session cookies, no posting)
-- Does not share API keys between providers (Groq key only goes to `api.groq.com`, OpenAI key only goes to `api.openai.com`)
+- Does not share API keys between providers (Groq key only goes to `api.groq.com`, AssemblyAI key only goes to `api.assemblyai.com`, OpenAI key only goes to `api.openai.com`)
 - Does not log, cache, or write API keys to stdout, stderr, or output files
 - Does not persist anything outside the working directory and `~/.config/watch/.env` — clean up the working directory when you're done (Step 5)
 
-**Bundled scripts:** `scripts/watch.py` (entry point), `scripts/download.py` (yt-dlp wrapper), `scripts/frames.py` (ffmpeg frame extraction), `scripts/transcribe.py` (caption selection + Whisper orchestration), `scripts/whisper.py` (Groq / OpenAI clients), `scripts/setup.py` (preflight + installer)
+**Bundled scripts:** `scripts/watch.py` (entry point), `scripts/download.py` (yt-dlp wrapper), `scripts/frames.py` (ffmpeg frame extraction), `scripts/transcribe.py` (caption selection + transcription orchestration), `scripts/whisper.py` (Groq / AssemblyAI / OpenAI clients), `scripts/setup.py` (preflight + installer)
 
 Review scripts before first use to verify behavior.

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -32,19 +32,24 @@ CONFIG_DIR = Path.home() / ".config" / "watch"
 CONFIG_FILE = CONFIG_DIR / ".env"
 ENV_TEMPLATE = """# /watch API configuration
 #
-# Whisper transcription fallback — used only when yt-dlp cannot get captions
+# Transcription fallback — used only when yt-dlp cannot get captions
 # (or when you point /watch at a local file with no subtitles).
 #
-# Groq is preferred: it runs whisper-large-v3 at a fraction of OpenAI's price
-# and is faster in practice. OpenAI is the compatible fallback.
+# Three backends supported. Auto-selected in cost-ascending order if multiple
+# keys are set; override with `--whisper {groq|assemblyai|openai}`:
 #
-# Get a Groq key:  https://console.groq.com/keys
-# Get an OpenAI key:  https://platform.openai.com/api-keys
+#   1. Groq         (~$0.04/h, fastest, whisper-large-v3)
+#      https://console.groq.com/keys
+#   2. AssemblyAI   (~$0.27/h, async with polling, strong PT-BR + diarization-ready)
+#      https://www.assemblyai.com/dashboard/signup
+#   3. OpenAI       (~$0.36/h, whisper-1)
+#      https://platform.openai.com/api-keys
 #
-# Leave both blank to disable Whisper — /watch will still work, but videos
-# without native captions will come back frames-only.
+# Leave all blank to disable transcription — /watch still works on videos
+# with native captions; videos without captions come back frames-only.
 
 GROQ_API_KEY=
+ASSEMBLYAI_API_KEY=
 OPENAI_API_KEY=
 """
 
@@ -96,8 +101,11 @@ def _read_env_key(name: str) -> str | None:
 
 
 def _have_api_key() -> tuple[bool, str | None]:
+    # Priority must match whisper.py:load_api_key — cost-ascending.
     if _read_env_key("GROQ_API_KEY"):
         return True, "groq"
+    if _read_env_key("ASSEMBLYAI_API_KEY"):
+        return True, "assemblyai"
     if _read_env_key("OPENAI_API_KEY"):
         return True, "openai"
     return False, None
@@ -238,7 +246,7 @@ def cmd_check() -> int:
     if s["missing_binaries"]:
         parts.append(f"missing binaries: {', '.join(s['missing_binaries'])}")
     if not s["has_api_key"]:
-        parts.append("no Whisper API key (GROQ_API_KEY or OPENAI_API_KEY)")
+        parts.append("no transcription API key (GROQ_API_KEY, ASSEMBLYAI_API_KEY, or OPENAI_API_KEY)")
     installer = Path(__file__).resolve()
     sys.stderr.write(
         f"[watch] setup incomplete ({'; '.join(parts)}). "
@@ -302,11 +310,12 @@ def cmd_install() -> int:
         return 0
 
     print("")
-    print("[setup] one step left: add a Whisper API key.")
+    print("[setup] one step left: add a transcription API key.")
     print("")
-    print(f"  Edit {CONFIG_FILE} and set either:")
-    print("    GROQ_API_KEY=...    (preferred — cheaper, faster; get one at console.groq.com/keys)")
-    print("    OPENAI_API_KEY=...  (fallback; get one at platform.openai.com/api-keys)")
+    print(f"  Edit {CONFIG_FILE} and set one of:")
+    print("    GROQ_API_KEY=...        (~$0.04/h, fastest; console.groq.com/keys)")
+    print("    ASSEMBLYAI_API_KEY=...  (~$0.27/h, strong PT-BR; assemblyai.com/dashboard/signup)")
+    print("    OPENAI_API_KEY=...      (~$0.36/h; platform.openai.com/api-keys)")
     print("")
     print("  Without a key, /watch still works but videos without captions come back frames-only.")
     return 3

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -40,9 +40,9 @@ def main() -> int:
     )
     ap.add_argument(
         "--whisper",
-        choices=["groq", "openai"],
+        choices=["groq", "assemblyai", "openai"],
         default=None,
-        help="Force a specific Whisper backend. Default: prefer Groq, fall back to OpenAI.",
+        help="Force a specific transcription backend. Default priority (cost-ascending): Groq → AssemblyAI → OpenAI.",
     )
     args = ap.parse_args()
 

--- a/scripts/whisper.py
+++ b/scripts/whisper.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
-"""Transcribe a video via Groq or OpenAI Whisper API.
+"""Transcribe a video via Groq, AssemblyAI, or OpenAI.
 
 Strategy: extract audio (mono 16kHz mp3, tiny payload), upload to whichever
 API has a key. Returns segments in the same shape as transcribe.parse_vtt so
 the rest of the pipeline (filter_range, format_transcript) doesn't care where
 the transcript came from.
 
-Pure stdlib — no `pip install groq` or `pip install openai` needed.
+Pure stdlib — no SDK dependencies. AssemblyAI is async (upload → create
+job → poll) so it has its own client path; Groq and OpenAI share the
+single-shot multipart Whisper path.
+
+Priority for auto-selection (cost-ascending): Groq > AssemblyAI > OpenAI.
 """
 from __future__ import annotations
 
@@ -30,6 +34,12 @@ GROQ_MODEL = "whisper-large-v3"
 
 OPENAI_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions"
 OPENAI_MODEL = "whisper-1"
+
+ASSEMBLYAI_BASE = "https://api.assemblyai.com/v2"
+ASSEMBLYAI_UPLOAD = f"{ASSEMBLYAI_BASE}/upload"
+ASSEMBLYAI_TRANSCRIPT = f"{ASSEMBLYAI_BASE}/transcript"
+ASSEMBLYAI_POLL_INTERVAL = 3.0
+ASSEMBLYAI_POLL_TIMEOUT = 1800.0  # 30 min — 3hr video typically completes in 10–15 min
 
 
 def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, None]:
@@ -65,7 +75,13 @@ def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, 
         Path.cwd() / ".env",
     ]
 
-    candidates = (("GROQ_API_KEY", "groq"), ("OPENAI_API_KEY", "openai"))
+    # Priority is cost-ascending: Groq cheapest, OpenAI most expensive.
+    # If the user has multiple keys configured, auto-select the cheapest.
+    candidates = (
+        ("GROQ_API_KEY", "groq"),
+        ("ASSEMBLYAI_API_KEY", "assemblyai"),
+        ("OPENAI_API_KEY", "openai"),
+    )
     if preferred is not None:
         candidates = tuple(c for c in candidates if c[1] == preferred)
 
@@ -261,6 +277,149 @@ def _segments_from_response(data: dict) -> list[dict]:
     return out
 
 
+def _post_assemblyai(api_key: str, audio_path: Path) -> dict:
+    """Upload audio + create transcript job + poll until completion.
+
+    AssemblyAI is a 3-step async API:
+      1. POST raw bytes to /v2/upload → returns {upload_url}
+      2. POST {audio_url} to /v2/transcript → returns {id, status: queued}
+      3. GET /v2/transcript/{id} repeatedly → status: completed | error
+
+    Auth uses bare key in `Authorization` (no `Bearer` prefix), unlike OpenAI/Groq.
+    """
+    base_headers = {
+        "Authorization": api_key,
+        # Set non-default UA on principle (Groq's WAF rejected default
+        # `Python-urllib`; AssemblyAI hasn't shown the same behavior, but
+        # identifying honestly costs nothing).
+        "User-Agent": "watch-skill/1.0 (+claude-code; python-urllib)",
+    }
+    context = ssl.create_default_context()
+
+    # --- Step 1: upload audio bytes ---
+    size_kb = audio_path.stat().st_size / 1024
+    print(f"[watch] uploading {size_kb:.0f} kB to AssemblyAI…", file=sys.stderr)
+    upload_req = Request(
+        ASSEMBLYAI_UPLOAD,
+        data=audio_path.read_bytes(),
+        headers={**base_headers, "Content-Type": "application/octet-stream"},
+        method="POST",
+    )
+    try:
+        with urlopen(upload_req, timeout=300, context=context) as resp:
+            upload_data = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"AssemblyAI upload failed: {exc}{_read_error_body(exc)}")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise SystemExit(f"AssemblyAI upload network error: {type(exc).__name__}: {exc}")
+    upload_url = upload_data.get("upload_url")
+    if not upload_url:
+        raise SystemExit(f"AssemblyAI upload returned no upload_url: {upload_data}")
+
+    # --- Step 2: create transcript job ---
+    payload = {
+        "audio_url": upload_url,
+        # Auto-detect handles the EN/PT mix on this skill's typical inputs.
+        "language_detection": True,
+    }
+    create_req = Request(
+        ASSEMBLYAI_TRANSCRIPT,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={**base_headers, "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(create_req, timeout=60, context=context) as resp:
+            create_data = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"AssemblyAI transcript create failed: {exc}{_read_error_body(exc)}")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise SystemExit(f"AssemblyAI create network error: {type(exc).__name__}: {exc}")
+    transcript_id = create_data.get("id")
+    if not transcript_id:
+        raise SystemExit(f"AssemblyAI returned no transcript id: {create_data}")
+
+    # --- Step 3: poll until completed or error ---
+    poll_url = f"{ASSEMBLYAI_TRANSCRIPT}/{transcript_id}"
+    print(f"[watch] AssemblyAI job {transcript_id} queued — polling…", file=sys.stderr)
+    deadline = time.monotonic() + ASSEMBLYAI_POLL_TIMEOUT
+    while time.monotonic() < deadline:
+        time.sleep(ASSEMBLYAI_POLL_INTERVAL)
+        poll_req = Request(poll_url, headers=base_headers, method="GET")
+        try:
+            with urlopen(poll_req, timeout=60, context=context) as resp:
+                data = json.loads(resp.read().decode("utf-8", errors="replace"))
+        except urllib.error.HTTPError as exc:
+            # Transient 5xx during poll — keep trying within deadline
+            if 500 <= exc.code < 600:
+                print(f"[watch] AssemblyAI poll HTTP {exc.code}, retrying", file=sys.stderr)
+                continue
+            raise SystemExit(f"AssemblyAI poll failed: {exc}{_read_error_body(exc)}")
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            print(f"[watch] AssemblyAI poll network error ({type(exc).__name__}: {exc}), retrying", file=sys.stderr)
+            continue
+
+        status = data.get("status")
+        if status == "completed":
+            return data
+        if status == "error":
+            raise SystemExit(f"AssemblyAI transcription failed: {data.get('error', 'unknown')}")
+        # else: 'queued' or 'processing' — keep polling
+
+    raise SystemExit(
+        f"AssemblyAI transcription timed out after {ASSEMBLYAI_POLL_TIMEOUT:.0f}s"
+    )
+
+
+def _segments_from_assemblyai(data: dict) -> list[dict]:
+    """Convert AssemblyAI response (per-word timestamps) to {start,end,text} segments.
+
+    AssemblyAI returns `words[]` with timestamps in milliseconds. We chunk
+    into ~5s segments to mirror Whisper's typical segment length, which keeps
+    the downstream filter_range/format_transcript code uniform across backends.
+    """
+    words = data.get("words") or []
+    if not words:
+        full = (data.get("text") or "").strip()
+        if full:
+            return [{"start": 0.0, "end": 0.0, "text": full}]
+        return []
+
+    SEG_DURATION = 5.0
+    segments: list[dict] = []
+    current: list[str] = []
+    seg_start: float | None = None
+    seg_end: float = 0.0
+
+    for w in words:
+        text = (w.get("text") or "").strip()
+        if not text:
+            continue
+        start_s = float(w.get("start") or 0) / 1000.0
+        end_s = float(w.get("end") or 0) / 1000.0
+        if seg_start is None:
+            seg_start = start_s
+        seg_end = end_s
+        current.append(text)
+        if (seg_end - seg_start) >= SEG_DURATION:
+            segments.append({
+                "start": round(seg_start, 2),
+                "end": round(seg_end, 2),
+                "text": " ".join(current),
+            })
+            current = []
+            seg_start = None
+
+    if current and seg_start is not None:
+        segments.append({
+            "start": round(seg_start, 2),
+            "end": round(seg_end, 2),
+            "text": " ".join(current),
+        })
+
+    return segments
+
+
 def transcribe_video(
     video_path: str,
     audio_out: Path,
@@ -279,26 +438,30 @@ def transcribe_video(
     if not backend or not api_key:
         setup_py = Path(__file__).resolve().parent / "setup.py"
         raise SystemExit(
-            "No Whisper API key available. Set GROQ_API_KEY (preferred) or OPENAI_API_KEY "
-            "in the environment or in ~/.config/watch/.env. "
-            f"Run `python3 {setup_py}` to configure."
+            "No transcription API key available. Set one of GROQ_API_KEY (preferred), "
+            "ASSEMBLYAI_API_KEY, or OPENAI_API_KEY in the environment or in "
+            f"~/.config/watch/.env. Run `python3 {setup_py}` to configure."
         )
 
-    print(f"[watch] extracting audio for Whisper ({backend})…", file=sys.stderr)
+    print(f"[watch] extracting audio for transcription ({backend})…", file=sys.stderr)
     audio_path = extract_audio(video_path, audio_out)
     size_kb = audio_path.stat().st_size / 1024
-    print(f"[watch] audio: {size_kb:.0f} kB — uploading to {backend} Whisper…", file=sys.stderr)
+    print(f"[watch] audio: {size_kb:.0f} kB — sending to {backend}…", file=sys.stderr)
 
     if backend == "groq":
         response = _post_whisper(GROQ_ENDPOINT, api_key, GROQ_MODEL, audio_path)
+        segments = _segments_from_response(response)
     elif backend == "openai":
         response = _post_whisper(OPENAI_ENDPOINT, api_key, OPENAI_MODEL, audio_path)
+        segments = _segments_from_response(response)
+    elif backend == "assemblyai":
+        response = _post_assemblyai(api_key, audio_path)
+        segments = _segments_from_assemblyai(response)
     else:
-        raise SystemExit(f"Unknown whisper backend: {backend}")
+        raise SystemExit(f"Unknown transcription backend: {backend}")
 
-    segments = _segments_from_response(response)
     if not segments:
-        raise SystemExit("Whisper returned no transcript segments")
+        raise SystemExit(f"{backend} returned no transcript segments")
 
     print(f"[watch] transcribed {len(segments)} segments via {backend}", file=sys.stderr)
     return segments, backend
@@ -306,7 +469,7 @@ def transcribe_video(
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("usage: whisper.py <video-path> [<audio-out.mp3>] [--backend groq|openai]", file=sys.stderr)
+        print("usage: whisper.py <video-path> [<audio-out.mp3>] [--backend groq|assemblyai|openai]", file=sys.stderr)
         raise SystemExit(2)
 
     video = sys.argv[1]


### PR DESCRIPTION
## Summary
- Adds **AssemblyAI** as a third transcription backend alongside Groq and OpenAI in `scripts/whisper.py`. Async client (upload → create job → poll up to 30 min), stdlib-only (no SDK dep) per the project's convention.
- Auto-priority becomes cost-ascending: Groq (~$0.04/h) → AssemblyAI (~$0.27/h) → OpenAI (~$0.36/h). Single-key users see no behavior change. Override with `--whisper {groq|assemblyai|openai}`.
- Strengths of AssemblyAI vs the existing options: stronger PT-BR transcription, auto language detection, and a much higher upload size ceiling than Groq/OpenAI's 25 MB limit (so long videos don't need chunking).

## Files touched
- `scripts/whisper.py` — `_post_assemblyai()` (upload → create → poll), `_segments_from_assemblyai()` chunks per-word into ~5s segments to match Whisper's segment shape so downstream `filter_range` / `format_transcript` need no changes. Priority chain in `load_api_key()` extended.
- `scripts/setup.py` — env template adds `ASSEMBLYAI_API_KEY`, `_have_api_key()` includes the new key in the same priority order, installer prompts and `--check` error message updated.
- `scripts/watch.py` — `--whisper` choices grew to `groq|assemblyai|openai` with cost-ascending help text.
- `SKILL.md` — usage section, transcription-fallback section, failure-mode hint, privacy notes, and bundled-scripts list now cover all three backends.
- `CHANGELOG.md` — `[0.2.0]` entry.
- `.claude-plugin/plugin.json` — version `0.1.2` → `0.2.0`, description rewritten.

## Test plan
- [x] `python -m py_compile scripts/whisper.py scripts/setup.py scripts/watch.py` — clean
- [x] `python scripts/setup.py --json` returns `status: ready` with new priority chain (single Groq key configured → `whisper_backend: groq`, no behavior regression)
- [ ] End-to-end against a video without captions using `--whisper assemblyai` (needs an AssemblyAI API key)
- [ ] `bash scripts/build-skill.sh` — release CI on tag push will run this; verify the bundle still respects the 200-file cap and single-`SKILL.md` invariants with the changes

## Notes
- AssemblyAI's auth header is the bare key (no `Bearer` prefix), and upload is raw bytes (not multipart). Kept the AssemblyAI client path separate from the existing Whisper multipart path to keep each provider's quirks isolated.
- Polling: 3s interval, 30 min hard timeout. AssemblyAI typically completes in real-time-fraction (e.g., 30 min audio in 2-3 min); 30 min cap covers ~3 h videos with margin.
- `--no-whisper` keeps working as a kill switch for the entire transcription path.