### PR TITLE
Add local Whisper backend (mlx_whisper / openai-whisper)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `/watch` are documented here.
 
+## [Unreleased]
+
+### Added
+- Local Whisper backend. `--whisper local` (or `WATCH_WHISPER_BACKEND=local`) shells to a local Whisper binary instead of POSTing to Groq/OpenAI — no API key needed and audio never leaves the machine. Auto-detects `mlx_whisper` (Apple Silicon) and `openai-whisper`, falling back to either when no cloud key is set. Override the binary with `WATCH_LOCAL_WHISPER_BIN` and the model with `WATCH_LOCAL_WHISPER_MODEL`.
+- `setup.py --json` and the SessionStart hook now report local Whisper availability; setup is considered "ready" when either a cloud key or a local binary is present.
+
+### Changed
+- `whisper.py` exports a new `resolve_backend(preferred)` helper that handles all three backends. The original `load_api_key` is preserved for backward compatibility but only knows about the cloud backends.
+
 ## [0.1.3] — 2026-05-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ On the first `/watch` call, the skill runs `scripts/setup.py --check`. If `ffmpe
 - **Linux** — prints the exact `apt` / `dnf` / `pipx` commands.
 - **Windows** — prints the `winget` / `pip` commands.
 - **API key** — scaffolds `~/.config/watch/.env` (mode `0600`) with commented placeholders for `GROQ_API_KEY` (preferred) and `OPENAI_API_KEY`.
+- **Local Whisper (no key)** — if you'd rather not use a cloud API, install `mlx_whisper` (Apple Silicon) or `openai-whisper` (cross-platform) and `/watch` will pick it up automatically. Force it with `--whisper local` or `WATCH_WHISPER_BACKEND=local`.
 
 After setup, preflight is silent and `/watch` just works. The check is a sub-100ms lookup, so it doesn't slow you down on subsequent runs.
 
@@ -123,8 +124,9 @@ Captions cover the majority of public videos for free. The Whisper fallback only
 | Capability | What you need | Cost |
 |------------|---------------|------|
 | Download + native captions | `yt-dlp` + `ffmpeg` | Free |
-| Whisper fallback (preferred) | [Groq API key](https://console.groq.com/keys) — `whisper-large-v3` | Cheap, fast |
-| Whisper fallback (alt) | [OpenAI API key](https://platform.openai.com/api-keys) — `whisper-1` | Standard pricing |
+| Whisper fallback (cloud, preferred) | [Groq API key](https://console.groq.com/keys) — `whisper-large-v3` | Cheap, fast |
+| Whisper fallback (cloud, alt) | [OpenAI API key](https://platform.openai.com/api-keys) — `whisper-1` | Standard pricing |
+| Whisper fallback (local) | `pip install mlx-whisper` (Apple Silicon) or `pip install -U openai-whisper` | Free, runs on-device |
 | Disable Whisper entirely | `--no-whisper` | Free, frames-only when no captions |
 
 ## Usage
@@ -148,7 +150,7 @@ Other knobs (passed to `scripts/watch.py`):
 - `--max-frames N` — lower the frame cap for a tighter token budget.
 - `--resolution W` — bump frame width to 1024 px when Claude needs to read on-screen text (slides, terminals, code).
 - `--fps F` — override the auto-fps calculation (still capped at 2 fps).
-- `--whisper groq|openai` — force a specific Whisper backend.
+- `--whisper groq|openai|local` — force a specific Whisper backend. The `local` backend shells to `mlx_whisper` or `openai-whisper` on your machine — no API key, no upload. Override the binary with `WATCH_LOCAL_WHISPER_BIN` and the model with `WATCH_LOCAL_WHISPER_MODEL`.
 - `--no-whisper` — disable transcription entirely; frames only.
 - `--out-dir DIR` — keep working files somewhere specific (default: auto-generated tmp dir).
 
@@ -156,7 +158,7 @@ Other knobs (passed to `scripts/watch.py`):
 
 - **Best accuracy: under 10 minutes.** Past that the script prints a "sparse scan" warning — re-run focused on the part you actually care about with `--start`/`--end`.
 - **Hard caps: 2 fps, 100 frames.** Frame count drives token cost; the script enforces this even when the auto-fps math would imply higher.
-- **Whisper upload limit: 25 MB.** At mono 16 kHz that's about 50 minutes of audio. Longer videos need either captions or `--start`/`--end` to a smaller window.
+- **Whisper upload limit: 25 MB.** Cloud-only — applies to Groq and OpenAI. At mono 16 kHz that's about 50 minutes of audio. Longer videos need either captions, `--start`/`--end` to a smaller window, or `--whisper local` (no upload limit; bound only by your disk and patience).
 - **No private platforms.** This skill doesn't log into anything. Public URLs and local files only. If yt-dlp can't reach it without auth, neither can `/watch`.
 
 ## Structure
@@ -169,7 +171,7 @@ Other knobs (passed to `scripts/watch.py`):
 │   ├── download.py          # yt-dlp wrapper
 │   ├── frames.py            # ffmpeg frame extraction + auto-fps logic
 │   ├── transcribe.py        # VTT parsing + dedupe + Whisper orchestration
-│   ├── whisper.py           # Groq / OpenAI clients (pure stdlib)
+│   ├── whisper.py           # Groq / OpenAI / local clients (pure stdlib)
 │   ├── setup.py             # preflight + installer
 │   └── build-skill.sh       # build dist/watch.skill for claude.ai upload
 ├── hooks/                   # SessionStart status hook (Claude Code only)

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,8 +31,8 @@ On non-zero exit, follow the table:
 | Exit | Meaning | Action |
 |------|---------|--------|
 | `2` | Missing binaries (`ffmpeg` / `ffprobe` / `yt-dlp`) | Run installer |
-| `3` | No Whisper API key | Run installer to scaffold `.env`, then ask user for a key |
-| `4` | Both missing | Run installer, then ask for a key |
+| `3` | No Whisper backend (no API key, no local binary) | Run installer to scaffold `.env`, then ask user for a key or suggest installing `mlx_whisper` / `openai-whisper` |
+| `4` | Both missing | Run installer, then resolve the Whisper side |
 
 The installer is idempotent — safe to re-run:
 
@@ -42,9 +42,9 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/setup.py"
 
 On macOS with Homebrew, it auto-installs `ffmpeg` and `yt-dlp`. On Linux/Windows, it prints the exact install commands for the user to run. It scaffolds `~/.config/watch/.env` with commented placeholders at `0600` perms, and writes `SETUP_COMPLETE=true` once deps + a key are in place so the next session knows this user has already been through the wizard.
 
-**If an API key is still missing after install:** use `AskUserQuestion` to ask the user whether they have a Groq API key (preferred — cheaper, faster) or an OpenAI key. Then write it into `~/.config/watch/.env` — set the matching `GROQ_API_KEY=...` or `OPENAI_API_KEY=...` line. If they don't want to set up Whisper, proceed with `--no-whisper` and tell them videos without native captions will come back frames-only.
+**If no Whisper backend is available after install:** use `AskUserQuestion` to offer three choices — Groq API key (preferred cloud — cheaper, faster), OpenAI API key, or local Whisper (no key, runs on-device via `mlx_whisper` on Apple Silicon or `openai-whisper` cross-platform). For cloud, write the key into `~/.config/watch/.env` (`GROQ_API_KEY=...` or `OPENAI_API_KEY=...`). For local, suggest `pip install mlx-whisper` or `pip install -U openai-whisper`; once the binary is on PATH the plugin auto-detects it. If they want to skip Whisper entirely, proceed with `--no-whisper` and tell them videos without native captions will come back frames-only.
 
-**Structured mode (optional):** `python3 "${CLAUDE_SKILL_DIR}/scripts/setup.py" --json` emits `{status, first_run, missing_binaries, whisper_backend, has_api_key, config_file, platform}` where `status` is one of `ready | needs_install | needs_key | needs_install_and_key`. Use this when you need to branch on specifics (e.g. "is this the user's very first run?" → `first_run: true`).
+**Structured mode (optional):** `python3 "${CLAUDE_SKILL_DIR}/scripts/setup.py" --json` emits `{status, first_run, missing_binaries, whisper_backend, has_api_key, local_whisper_bin, config_file, platform}` where `status` is one of `ready | needs_install | needs_key | needs_install_and_key`. Use this when you need to branch on specifics (e.g. "is this the user's very first run?" → `first_run: true`, or "do they have a local backend?" → `local_whisper_bin` is the path or `null`).
 
 Within a single session, you can skip Step 0 on follow-up `/watch` calls — once `--check` returned 0, nothing about the environment changes between turns.
 
@@ -81,7 +81,7 @@ Optional flags:
 - `--resolution W` — change frame width in px (default 512; bump to 1024 only if the user needs to read on-screen text)
 - `--fps F` — override auto-fps (clamped to 2 fps max)
 - `--out-dir DIR` — keep working files somewhere specific (default: an auto-generated tmp dir)
-- `--whisper groq|openai` — force a specific Whisper backend (default: prefer Groq if both keys exist)
+- `--whisper groq|openai|local` — force a specific Whisper backend (default: prefer Groq if a key exists, else OpenAI, else a local binary). Override globally via `WATCH_WHISPER_BACKEND`.
 - `--no-whisper` — disable the Whisper fallback entirely (frames-only if no captions)
 
 ### Focusing on a section (higher frame rate)
@@ -117,7 +117,7 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/watch.py" "$URL" --start 1:12:00
 
 **Step 4 — answer the user.** You now have two streams of evidence:
 - **Frames** — what's on screen at each timestamp
-- **Transcript** — what's said at each timestamp. The report's header shows the source (`captions` = yt-dlp pulled native subs; `whisper (groq)` or `whisper (openai)` = transcribed by API).
+- **Transcript** — what's said at each timestamp. The report's header shows the source (`captions` = yt-dlp pulled native subs; `whisper (groq)` / `whisper (openai)` = transcribed via cloud API; `whisper (local)` = transcribed by an on-device binary, audio never left the machine).
 
 If the user asked a specific question, answer it directly citing timestamps. If they didn't ask anything, summarize what happens in the video — structure, key moments, notable visuals, spoken content.
 
@@ -128,19 +128,20 @@ If the user asked a specific question, answer it directly citing timestamps. If 
 The script gets a timestamped transcript in one of two ways:
 
 1. **Native captions (free, preferred).** yt-dlp pulls manual or auto-generated subtitles from the source platform if available.
-2. **Whisper API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever Whisper API has a key configured:
-   - **Groq** — `whisper-large-v3`. Preferred default: cheaper, faster. Get a key at console.groq.com/keys.
-   - **OpenAI** — `whisper-1`. Fallback. Get a key at platform.openai.com/api-keys.
+2. **Whisper fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and routes it to whichever backend is configured:
+   - **Groq** (cloud) — `whisper-large-v3`. Preferred default: cheaper, faster. Get a key at console.groq.com/keys.
+   - **OpenAI** (cloud) — `whisper-1`. Fallback. Get a key at platform.openai.com/api-keys.
+   - **Local** — shells to `mlx_whisper` (Apple Silicon) or `openai-whisper` on PATH. No API key, no upload, no per-minute cost. Override the binary with `WATCH_LOCAL_WHISPER_BIN` and the model with `WATCH_LOCAL_WHISPER_MODEL`.
 
-Both keys live in `~/.config/watch/.env`. The script prefers Groq when both are set; override with `--whisper openai` to force OpenAI. Use `--no-whisper` to skip the fallback entirely.
+Cloud keys live in `~/.config/watch/.env`. Resolution order when a backend isn't forced: explicit `--whisper` → `WATCH_WHISPER_BACKEND` env → Groq key → OpenAI key → local binary. Use `--no-whisper` to skip the fallback entirely.
 
 ## Failure modes and handling
 
 - **Setup preflight failed** → run `python3 "${CLAUDE_SKILL_DIR}/scripts/setup.py"` (auto-installs ffmpeg/yt-dlp via brew on macOS, scaffolds the `.env`). For API key, ask the user via `AskUserQuestion` and write it to `~/.config/watch/.env`.
-- **No transcript available** → captions missing AND (no Whisper key OR Whisper API failed). Script prints a hint pointing to setup. Proceed frames-only and tell the user.
+- **No transcript available** → captions missing AND (no Whisper backend OR Whisper transcription failed). Script prints a hint pointing to setup. Proceed frames-only and tell the user.
 - **Long video warning printed** → acknowledge it in your answer. Offer to re-run focused on a specific section via `--start`/`--end` rather than a sparse full-video scan.
 - **Download fails** → yt-dlp's error goes to stderr. If it's a login-required or region-locked video, tell the user plainly; do not keep retrying.
-- **Whisper request fails** → the error is printed to stderr (likely: invalid key, rate limit, or 25 MB upload limit on a very long video). The report will say "none available" for transcript. You can retry with `--whisper openai` if Groq failed (or vice versa).
+- **Whisper request fails** → the error is printed to stderr. Cloud failures are typically invalid key / rate limit / 25 MB upload cap on long videos; local failures are typically a missing binary or a bad model id. The report will say "none available" for transcript. You can retry with a different `--whisper` backend (e.g. cloud → local for offline, or vice versa for speed).
 
 ## Token efficiency
 
@@ -158,6 +159,7 @@ If you already watched a video this session and the user asks a follow-up, do **
 - Runs `ffmpeg` / `ffprobe` locally to extract frames as JPEGs and, when Whisper is needed, a mono 16 kHz audio clip
 - Sends the extracted audio clip to Groq's Whisper API (`api.groq.com/openai/v1/audio/transcriptions`) when `GROQ_API_KEY` is set (preferred — cheaper, faster)
 - Sends the extracted audio clip to OpenAI's audio transcription API (`api.openai.com/v1/audio/transcriptions`) when `OPENAI_API_KEY` is set and Groq is not, or when `--whisper openai` is forced
+- Shells to a local Whisper binary (`mlx_whisper` / `openai-whisper`, or whatever `WATCH_LOCAL_WHISPER_BIN` points at) when `--whisper local` is forced or no cloud key is configured. Audio stays on the machine in this mode — nothing leaves localhost.
 - Writes the downloaded video, frames, audio, and an intermediate transcript to a working directory under the system temp dir (or `--out-dir` if specified) so Claude can `Read` them
 - Reads / creates `~/.config/watch/.env` (mode `0600`) to store the Whisper API key(s) and a `SETUP_COMPLETE` marker. As a fallback, also reads `.env` in the current working directory
 
@@ -168,6 +170,6 @@ If you already watched a video this session and the user asks a follow-up, do **
 - Does not log, cache, or write API keys to stdout, stderr, or output files
 - Does not persist anything outside the working directory and `~/.config/watch/.env` — clean up the working directory when you're done (Step 5)
 
-**Bundled scripts:** `scripts/watch.py` (entry point), `scripts/download.py` (yt-dlp wrapper), `scripts/frames.py` (ffmpeg frame extraction), `scripts/transcribe.py` (caption selection + Whisper orchestration), `scripts/whisper.py` (Groq / OpenAI clients), `scripts/setup.py` (preflight + installer)
+**Bundled scripts:** `scripts/watch.py` (entry point), `scripts/download.py` (yt-dlp wrapper), `scripts/frames.py` (ffmpeg frame extraction), `scripts/transcribe.py` (caption selection + Whisper orchestration), `scripts/whisper.py` (Groq / OpenAI / local clients), `scripts/setup.py` (preflight + installer)
 
 Review scripts before first use to verify behavior.

--- a/hooks/scripts/check-setup.sh
+++ b/hooks/scripts/check-setup.sh
@@ -36,8 +36,24 @@ read_key() {
 
 HAS_FFMPEG=""
 HAS_YTDLP=""
+HAS_LOCAL_WHISPER=""
 command -v ffmpeg >/dev/null 2>&1 && HAS_FFMPEG="yes"
 command -v yt-dlp >/dev/null 2>&1 && HAS_YTDLP="yes"
+
+# Probe for a local Whisper binary in priority order (override-respecting).
+LOCAL_BIN_OVERRIDE="$(read_key WATCH_LOCAL_WHISPER_BIN)"
+if [[ -n "$LOCAL_BIN_OVERRIDE" ]]; then
+  if command -v "$LOCAL_BIN_OVERRIDE" >/dev/null 2>&1 || [[ -x "$LOCAL_BIN_OVERRIDE" ]]; then
+    HAS_LOCAL_WHISPER="yes"
+  fi
+else
+  for candidate in mlx_whisper whisper; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      HAS_LOCAL_WHISPER="yes"
+      break
+    fi
+  done
+fi
 
 HAS_GROQ="$(read_key GROQ_API_KEY)"
 HAS_OPENAI="$(read_key OPENAI_API_KEY)"
@@ -51,8 +67,8 @@ fi
 # First-run / partially-configured → one-line hint.
 if [[ -z "$HAS_FFMPEG" || -z "$HAS_YTDLP" ]]; then
   echo "/watch: needs ffmpeg + yt-dlp. Run \`python3 \$CLAUDE_PLUGIN_ROOT/scripts/setup.py\` once to install and scaffold config."
-elif [[ -z "$HAS_GROQ" && -z "$HAS_OPENAI" ]]; then
-  echo "/watch: ready for videos with native captions. Add GROQ_API_KEY (preferred) or OPENAI_API_KEY to ~/.config/watch/.env to unlock Whisper fallback."
+elif [[ -z "$HAS_GROQ" && -z "$HAS_OPENAI" && -z "$HAS_LOCAL_WHISPER" ]]; then
+  echo "/watch: ready for videos with native captions. Unlock Whisper fallback by either: setting GROQ_API_KEY / OPENAI_API_KEY in ~/.config/watch/.env, or installing mlx_whisper / openai-whisper for the local backend."
 else
   echo "/watch: ready."
 fi

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -28,21 +28,32 @@ from pathlib import Path
 
 
 REQUIRED_BINARIES = ["ffmpeg", "ffprobe", "yt-dlp"]
+LOCAL_WHISPER_BINARIES = ("mlx_whisper", "whisper")
 CONFIG_DIR = Path.home() / ".config" / "watch"
 CONFIG_FILE = CONFIG_DIR / ".env"
-ENV_TEMPLATE = """# /watch API configuration
+ENV_TEMPLATE = """# /watch configuration
 #
 # Whisper transcription fallback — used only when yt-dlp cannot get captions
 # (or when you point /watch at a local file with no subtitles).
 #
-# Groq is preferred: it runs whisper-large-v3 at a fraction of OpenAI's price
-# and is faster in practice. OpenAI is the compatible fallback.
+# Three backends, picked in this order: explicit --whisper flag → cloud key
+# (Groq, then OpenAI) → local Whisper binary (mlx_whisper / openai-whisper).
 #
-# Get a Groq key:  https://console.groq.com/keys
-# Get an OpenAI key:  https://platform.openai.com/api-keys
+# Cloud (fastest, requires a key):
+#   Get a Groq key:    https://console.groq.com/keys
+#   Get an OpenAI key: https://platform.openai.com/api-keys
 #
-# Leave both blank to disable Whisper — /watch will still work, but videos
-# without native captions will come back frames-only.
+# Local (no key, runs on-device):
+#   pip install mlx-whisper            # Apple Silicon — fastest local option
+#   pip install -U openai-whisper      # cross-platform CPU/GPU
+#
+# Optional knobs:
+#   WATCH_WHISPER_BACKEND=local        # force a backend (groq | openai | local)
+#   WATCH_LOCAL_WHISPER_BIN=/path/...  # use a specific local binary
+#   WATCH_LOCAL_WHISPER_MODEL=...      # model id for the local backend
+#
+# Leave everything blank to disable Whisper — /watch will still work, but
+# videos without native captions will come back frames-only.
 
 GROQ_API_KEY=
 OPENAI_API_KEY=
@@ -101,6 +112,22 @@ def _have_api_key() -> tuple[bool, str | None]:
     if _read_env_key("OPENAI_API_KEY"):
         return True, "openai"
     return False, None
+
+
+def _have_local_whisper() -> str | None:
+    """Return the path to a local Whisper binary, or None.
+
+    Honours WATCH_LOCAL_WHISPER_BIN as an override; otherwise probes for
+    mlx_whisper (Apple Silicon) and openai-whisper (cross-platform).
+    """
+    override = _read_env_key("WATCH_LOCAL_WHISPER_BIN")
+    if override:
+        return _which(override) or (override if Path(override).exists() else None)
+    for name in LOCAL_WHISPER_BINARIES:
+        path = _which(name)
+        if path:
+            return path
+    return None
 
 
 def is_first_run() -> bool:
@@ -200,10 +227,17 @@ def _status() -> dict:
     """Structured preflight snapshot."""
     missing = _check_binaries()
     has_key, backend = _have_api_key()
+    local_bin = _have_local_whisper()
+    has_whisper = has_key or local_bin is not None
 
-    if not missing and has_key:
+    # Pick a single backend label for the snapshot. Cloud key wins when both
+    # are present; the local binary is a silent fallback.
+    if backend is None and local_bin:
+        backend = "local"
+
+    if not missing and has_whisper:
         status = "ready"
-    elif missing and not has_key:
+    elif missing and not has_whisper:
         status = "needs_install_and_key"
     elif missing:
         status = "needs_install"
@@ -216,6 +250,7 @@ def _status() -> dict:
         "missing_binaries": missing,
         "whisper_backend": backend,
         "has_api_key": has_key,
+        "local_whisper_bin": local_bin,
         "config_file": str(CONFIG_FILE),
         "platform": platform.system(),
     }
@@ -227,18 +262,22 @@ def cmd_check() -> int:
     Exit 0 with no output when ready. On failure, print one actionable line
     to stderr and return:
       2 → binaries missing
-      3 → API key missing
+      3 → no Whisper backend (key or local binary)
       4 → both missing
     """
     s = _status()
     if s["status"] == "ready":
         return 0
 
+    no_whisper = not s["has_api_key"] and not s["local_whisper_bin"]
     parts = []
     if s["missing_binaries"]:
         parts.append(f"missing binaries: {', '.join(s['missing_binaries'])}")
-    if not s["has_api_key"]:
-        parts.append("no Whisper API key (GROQ_API_KEY or OPENAI_API_KEY)")
+    if no_whisper:
+        parts.append(
+            "no Whisper backend (GROQ_API_KEY, OPENAI_API_KEY, "
+            "or local mlx_whisper / openai-whisper)"
+        )
     installer = Path(__file__).resolve()
     sys.stderr.write(
         f"[watch] setup incomplete ({'; '.join(parts)}). "
@@ -246,7 +285,7 @@ def cmd_check() -> int:
     )
     sys.stderr.flush()
 
-    if s["missing_binaries"] and not s["has_api_key"]:
+    if s["missing_binaries"] and no_whisper:
         return 4
     if s["missing_binaries"]:
         return 2
@@ -294,21 +333,30 @@ def cmd_install() -> int:
         print(f"[setup] config exists: {CONFIG_FILE}")
 
     has_key, backend = _have_api_key()
-    if has_key:
+    local_bin = _have_local_whisper()
+    if has_key or local_bin:
         _write_setup_complete()
-        print(f"[setup] ready. whisper backend: {backend}")
+        active = backend or ("local" if local_bin else None)
+        print(f"[setup] ready. whisper backend: {active}")
+        if local_bin and not has_key:
+            print(f"[setup] using local whisper at {local_bin}.")
         if installed_deps:
             print("[setup] installed dependencies; /watch is fully set up.")
         return 0
 
     print("")
-    print("[setup] one step left: add a Whisper API key.")
+    print("[setup] one step left: add a Whisper backend.")
     print("")
-    print(f"  Edit {CONFIG_FILE} and set either:")
+    print(f"  Cloud (fastest): edit {CONFIG_FILE} and set either:")
     print("    GROQ_API_KEY=...    (preferred — cheaper, faster; get one at console.groq.com/keys)")
     print("    OPENAI_API_KEY=...  (fallback; get one at platform.openai.com/api-keys)")
     print("")
-    print("  Without a key, /watch still works but videos without captions come back frames-only.")
+    print("  Local (no key, runs on-device):")
+    print("    pip install mlx-whisper          # Apple Silicon — fastest local option")
+    print("    pip install -U openai-whisper    # cross-platform CPU/GPU")
+    print("    # or set WATCH_LOCAL_WHISPER_BIN to a compatible binary")
+    print("")
+    print("  Without any backend, /watch still works but videos without captions come back frames-only.")
     return 3
 
 

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 from download import download, is_url  # noqa: E402
 from frames import MAX_FPS, auto_fps, auto_fps_focus, extract, format_time, get_metadata, parse_time  # noqa: E402
 from transcribe import filter_range, format_transcript, parse_vtt  # noqa: E402
-from whisper import load_api_key, transcribe_video  # noqa: E402
+from whisper import resolve_backend, transcribe_video  # noqa: E402
 
 
 def main() -> int:
@@ -40,9 +40,13 @@ def main() -> int:
     )
     ap.add_argument(
         "--whisper",
-        choices=["groq", "openai"],
+        choices=["groq", "openai", "local"],
         default=None,
-        help="Force a specific Whisper backend. Default: prefer Groq, fall back to OpenAI.",
+        help=(
+            "Force a specific Whisper backend. Default: prefer Groq, then OpenAI, "
+            "then a local Whisper binary (mlx_whisper / openai-whisper). "
+            "Override via WATCH_WHISPER_BACKEND."
+        ),
     )
     args = ap.parse_args()
 
@@ -117,14 +121,14 @@ def main() -> int:
             print(f"[watch] subtitle parse failed: {exc}", file=sys.stderr)
 
     if not transcript_segments and not args.no_whisper:
-        backend, api_key = load_api_key(args.whisper)
-        if backend and api_key:
+        backend, credential = resolve_backend(args.whisper)
+        if backend and credential:
             try:
                 all_segments, used_backend = transcribe_video(
                     video_path,
                     work / "audio.mp3",
                     backend=backend,
-                    api_key=api_key,
+                    api_key=credential,
                 )
                 transcript_segments = filter_range(all_segments, start_sec, end_sec) if focused else all_segments
                 transcript_text = format_transcript(transcript_segments)
@@ -132,14 +136,18 @@ def main() -> int:
             except SystemExit as exc:
                 print(f"[watch] whisper fallback failed: {exc}", file=sys.stderr)
         else:
-            hint = (
-                f"--whisper {args.whisper} was set but the matching API key is missing"
-                if args.whisper else
-                "no subtitles and no Whisper API key found"
-            )
+            if args.whisper == "local":
+                hint = (
+                    "--whisper local was set but no local Whisper binary was found "
+                    "(install mlx_whisper or openai-whisper, or set WATCH_LOCAL_WHISPER_BIN)"
+                )
+            elif args.whisper:
+                hint = f"--whisper {args.whisper} was set but the matching API key is missing"
+            else:
+                hint = "no subtitles, no Whisper API key, and no local Whisper binary"
             setup_py = SCRIPT_DIR / "setup.py"
             print(
-                f"[watch] {hint} — run `python3 {setup_py}` to enable the Whisper fallback",
+                f"[watch] {hint} — run `python3 {setup_py}` to configure",
                 file=sys.stderr,
             )
 

--- a/scripts/whisper.py
+++ b/scripts/whisper.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""Transcribe a video via Groq or OpenAI Whisper API.
+"""Transcribe a video via Groq, OpenAI, or a local Whisper CLI.
 
-Strategy: extract audio (mono 16kHz mp3, tiny payload), upload to whichever
-API has a key. Returns segments in the same shape as transcribe.parse_vtt so
-the rest of the pipeline (filter_range, format_transcript) doesn't care where
-the transcript came from.
+Strategy: extract audio (mono 16kHz mp3, tiny payload), then either upload to
+whichever cloud API has a key, or shell out to a local Whisper binary
+(mlx_whisper on Apple Silicon, openai-whisper, or any drop-in that accepts
+`--output-format json --output-dir`). Returns segments in the same shape as
+transcribe.parse_vtt so the rest of the pipeline (filter_range,
+format_transcript) doesn't care where the transcript came from.
 
 Pure stdlib — no `pip install groq` or `pip install openai` needed.
 """
@@ -31,53 +33,124 @@ GROQ_MODEL = "whisper-large-v3"
 OPENAI_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions"
 OPENAI_MODEL = "whisper-1"
 
+# Local backend — searched in order; first present binary wins. mlx_whisper is
+# Apple-Silicon-optimised and ships with the same CLI shape as openai-whisper,
+# so a single call site handles both. Override with WATCH_LOCAL_WHISPER_BIN.
+LOCAL_BIN_CANDIDATES = ("mlx_whisper", "whisper")
+LOCAL_DEFAULT_MODEL_MLX = "mlx-community/whisper-large-v3-turbo"
+LOCAL_DEFAULT_MODEL_OPENAI = "large-v3"
+
+
+def _from_env(name: str) -> str | None:
+    value = os.environ.get(name)
+    return value.strip() if value else None
+
+
+def _from_dotenv(path: Path, name: str) -> str | None:
+    if not path.exists():
+        return None
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            if key.strip() != name:
+                continue
+            value = value.strip()
+            if len(value) >= 2 and value[0] in ('"', "'") and value[-1] == value[0]:
+                value = value[1:-1]
+            return value or None
+    except OSError:
+        return None
+    return None
+
+
+def _read_setting(name: str) -> str | None:
+    """Read a config value from env first, then ~/.config/watch/.env, then ./.env."""
+    value = _from_env(name)
+    if value:
+        return value
+    for candidate in (Path.home() / ".config" / "watch" / ".env", Path.cwd() / ".env"):
+        value = _from_dotenv(candidate, name)
+        if value:
+            return value
+    return None
+
+
+def _resolve_local_bin() -> str | None:
+    """Return absolute path to a usable local Whisper binary, or None.
+
+    Honours WATCH_LOCAL_WHISPER_BIN as an override, otherwise probes
+    LOCAL_BIN_CANDIDATES in order.
+    """
+    override = _read_setting("WATCH_LOCAL_WHISPER_BIN")
+    if override:
+        path = shutil.which(override) or (override if Path(override).exists() else None)
+        if path:
+            return path
+        return None
+    for name in LOCAL_BIN_CANDIDATES:
+        path = shutil.which(name)
+        if path:
+            return path
+    return None
+
 
 def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, None]:
     """Return (backend, api_key). Prefers Groq, falls back to OpenAI.
 
     If `preferred` is "groq" or "openai", only that backend's key is considered.
+    Local backend is handled by `resolve_backend`; this helper stays focused on
+    the cloud-key flow so callers that only care about API keys don't change.
     """
-    def _from_env(name: str) -> str | None:
-        value = os.environ.get(name)
-        return value.strip() if value else None
-
-    def _from_dotenv(path: Path, name: str) -> str | None:
-        if not path.exists():
-            return None
-        try:
-            for line in path.read_text(encoding="utf-8").splitlines():
-                line = line.strip()
-                if not line or line.startswith("#") or "=" not in line:
-                    continue
-                key, _, value = line.partition("=")
-                if key.strip() != name:
-                    continue
-                value = value.strip()
-                if len(value) >= 2 and value[0] in ('"', "'") and value[-1] == value[0]:
-                    value = value[1:-1]
-                return value or None
-        except OSError:
-            return None
-        return None
-
-    dotenv_paths = [
-        Path.home() / ".config" / "watch" / ".env",
-        Path.cwd() / ".env",
-    ]
-
     candidates = (("GROQ_API_KEY", "groq"), ("OPENAI_API_KEY", "openai"))
     if preferred is not None:
         candidates = tuple(c for c in candidates if c[1] == preferred)
 
     for key_name, backend in candidates:
-        value = _from_env(key_name)
-        if not value:
-            for candidate in dotenv_paths:
-                value = _from_dotenv(candidate, key_name)
-                if value:
-                    break
+        value = _read_setting(key_name)
         if value:
             return backend, value
+
+    return None, None
+
+
+def resolve_backend(preferred: str | None = None) -> tuple[str | None, str | None]:
+    """Pick a Whisper backend.
+
+    Returns (backend, credential):
+      - ("groq",   api_key)
+      - ("openai", api_key)
+      - ("local",  bin_path)
+      - (None, None)  no backend available
+
+    Resolution order:
+      1. Explicit `preferred` argument (from --whisper).
+      2. WATCH_WHISPER_BACKEND env / .env (groq | openai | local).
+      3. Cloud key auto-detect (Groq → OpenAI).
+      4. Local binary auto-detect (mlx_whisper → whisper).
+    """
+    if preferred == "local":
+        bin_path = _resolve_local_bin()
+        return ("local", bin_path) if bin_path else (None, None)
+    if preferred in ("groq", "openai"):
+        backend, key = load_api_key(preferred)
+        return (backend, key) if backend else (None, None)
+
+    env_pref = _read_setting("WATCH_WHISPER_BACKEND")
+    if env_pref:
+        env_pref = env_pref.lower().strip()
+        if env_pref in ("groq", "openai", "local"):
+            return resolve_backend(env_pref)
+
+    backend, key = load_api_key()
+    if backend:
+        return backend, key
+
+    bin_path = _resolve_local_bin()
+    if bin_path:
+        return "local", bin_path
 
     return None, None
 
@@ -261,38 +334,100 @@ def _segments_from_response(data: dict) -> list[dict]:
     return out
 
 
+def _default_local_model(bin_path: str) -> str:
+    """Pick a sensible default model id for the detected binary."""
+    name = Path(bin_path).name
+    if name == "mlx_whisper":
+        return LOCAL_DEFAULT_MODEL_MLX
+    return LOCAL_DEFAULT_MODEL_OPENAI
+
+
+def _post_local(bin_path: str, audio_path: Path, work_dir: Path) -> dict:
+    """Run a local Whisper binary and parse its JSON output.
+
+    Both mlx_whisper and openai-whisper share a CLI shape:
+      <bin> <audio> --output-format json --output-dir <dir> [--model <id>]
+
+    They write `<audio_stem>.json` into <dir> with the same {text, segments}
+    shape returned by the Whisper API. We parse that and reuse
+    `_segments_from_response`.
+    """
+    work_dir.mkdir(parents=True, exist_ok=True)
+    model = _read_setting("WATCH_LOCAL_WHISPER_MODEL") or _default_local_model(bin_path)
+
+    cmd = [
+        bin_path,
+        str(audio_path.resolve()),
+        "--output-format", "json",
+        "--output-dir", str(work_dir.resolve()),
+        "--model", model,
+    ]
+    print(
+        f"[watch] running local whisper: {Path(bin_path).name} (model={model})…",
+        file=sys.stderr,
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout or "").strip().splitlines()[-5:]
+        raise SystemExit(
+            f"Local whisper ({Path(bin_path).name}) failed (exit {result.returncode}): "
+            + " | ".join(tail)
+        )
+
+    json_path = work_dir / f"{audio_path.stem}.json"
+    if not json_path.exists():
+        # Some forks write the file using the resolved-symlink stem; fall back
+        # to the first .json in work_dir.
+        candidates = sorted(work_dir.glob("*.json"))
+        if not candidates:
+            raise SystemExit(f"Local whisper produced no JSON in {work_dir}")
+        json_path = candidates[0]
+
+    try:
+        return json.loads(json_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"Local whisper JSON parse failed: {exc}")
+
+
 def transcribe_video(
     video_path: str,
     audio_out: Path,
     backend: str | None = None,
     api_key: str | None = None,
 ) -> tuple[list[dict], str]:
-    """Run the full flow: extract audio → upload → parse segments.
+    """Run the full flow: extract audio → transcribe → parse segments.
+
+    `api_key` carries the cloud API key for groq/openai backends, and the
+    absolute path to the local Whisper binary for backend="local". Callers can
+    pass `None` to trigger auto-resolution via `resolve_backend`.
 
     Returns (segments, backend_used). Raises SystemExit on any failure.
     """
     if backend is None or api_key is None:
-        detected_backend, detected_key = load_api_key()
+        detected_backend, detected_credential = resolve_backend(backend)
         backend = backend or detected_backend
-        api_key = api_key or detected_key
+        api_key = api_key or detected_credential
 
     if not backend or not api_key:
         setup_py = Path(__file__).resolve().parent / "setup.py"
         raise SystemExit(
-            "No Whisper API key available. Set GROQ_API_KEY (preferred) or OPENAI_API_KEY "
-            "in the environment or in ~/.config/watch/.env. "
+            "No Whisper backend available. Set GROQ_API_KEY (preferred) or "
+            "OPENAI_API_KEY for cloud, or install mlx_whisper / openai-whisper "
+            "for the local backend. "
             f"Run `python3 {setup_py}` to configure."
         )
 
     print(f"[watch] extracting audio for Whisper ({backend})…", file=sys.stderr)
     audio_path = extract_audio(video_path, audio_out)
     size_kb = audio_path.stat().st_size / 1024
-    print(f"[watch] audio: {size_kb:.0f} kB — uploading to {backend} Whisper…", file=sys.stderr)
+    print(f"[watch] audio: {size_kb:.0f} kB — transcribing via {backend}…", file=sys.stderr)
 
     if backend == "groq":
         response = _post_whisper(GROQ_ENDPOINT, api_key, GROQ_MODEL, audio_path)
     elif backend == "openai":
         response = _post_whisper(OPENAI_ENDPOINT, api_key, OPENAI_MODEL, audio_path)
+    elif backend == "local":
+        response = _post_local(api_key, audio_path, audio_path.parent / "local-whisper")
     else:
         raise SystemExit(f"Unknown whisper backend: {backend}")
 
@@ -306,7 +441,11 @@ def transcribe_video(
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("usage: whisper.py <video-path> [<audio-out.mp3>] [--backend groq|openai]", file=sys.stderr)
+        print(
+            "usage: whisper.py <video-path> [<audio-out.mp3>] "
+            "[--backend groq|openai|local]",
+            file=sys.stderr,
+        )
         raise SystemExit(2)
 
     video = sys.argv[1]


### PR DESCRIPTION
## Summary

Adds a third Whisper backend that shells to a local binary instead of POSTing audio to Groq or OpenAI. Useful for:

- **Offline use** — `/watch` works on a plane / behind a corporate proxy.
- **Privacy** — audio never leaves the machine.
- **The 25 MB cap** — local has no upload limit, so long-form videos with no captions stop being a problem.
- **Apple Silicon speed** — `mlx_whisper` runs `whisper-large-v3-turbo` faster than the cloud round-trip on an M-series machine, with no per-call cost.

The implementation reuses the existing audio-extraction step (mono 16 kHz mp3) and shells to a binary that takes the openai-whisper CLI shape:

```
<bin> <audio> --output-format json --output-dir <dir> [--model <id>]
```

`mlx_whisper` and `openai-whisper` both expose this exact CLI, so one code path handles both. The resulting `<stem>.json` matches the Whisper API `verbose_json` schema, so `_segments_from_response` works unchanged.

## How to use

```bash
/watch ~/Movies/clip.mov                  # auto-detected if no cloud key set
/watch <url> --whisper local              # force the local backend
WATCH_WHISPER_BACKEND=local /watch <url>  # global override
```

Optional knobs:

- `WATCH_LOCAL_WHISPER_BIN=/path/to/binary` — point at any compatible binary.
- `WATCH_LOCAL_WHISPER_MODEL=large-v3` — override the model id.

## Resolution order

When `--whisper` isn't set, the priority is:

1. `WATCH_WHISPER_BACKEND` env / `.env` (groq | openai | local)
2. `GROQ_API_KEY`
3. `OPENAI_API_KEY`
4. local binary (`mlx_whisper` → `openai-whisper`)

So existing users see **zero behaviour change** — cloud keys still win when present. Local only kicks in when nothing else is configured, or when explicitly requested.

## Changes

- `scripts/whisper.py` — new `resolve_backend()` helper, `_post_local()` runner, `_resolve_local_bin()` probe. `load_api_key()` retained unchanged for back-compat with anyone importing it.
- `scripts/watch.py` — `--whisper` accepts `local`; uses `resolve_backend`; targeted hint when `--whisper local` fires without a binary on PATH.
- `scripts/setup.py` — `_have_local_whisper()` probe; `--check` / `--json` / installer report the local backend; setup is "ready" when either a cloud key or a local binary is present. `local_whisper_bin` added to the `--json` snapshot.
- `hooks/scripts/check-setup.sh` — SessionStart hook is silent when local Whisper is available, even with no cloud key.
- `README.md` / `SKILL.md` / `CHANGELOG.md` — documentation.

## Test plan

- [x] `python3 scripts/whisper.py /tmp/test.mp3 --backend local` end-to-end on Apple Silicon with `mlx-community/whisper-large-v3-turbo` — JSON parses, segments normalise to `{start, end, text}`.
- [x] `resolve_backend(None)` returns `("local", "/opt/homebrew/bin/mlx_whisper")` when no cloud key is set.
- [x] `resolve_backend("groq")` returns `(None, None)` when GROQ_API_KEY is unset (existing behaviour preserved).
- [x] `setup.py --check` exits 0 with no output when local binary is present and no cloud key is set.
- [x] `hooks/scripts/check-setup.sh` exits 0 with no output in the same situation (after first run).
- [ ] CI: I haven't run the existing test suite — there isn't one in the repo. Happy to add unit tests for `resolve_backend` if you'd like.

## Notes for review

- I kept `load_api_key()` exported and unchanged so external callers don't break. New code uses `resolve_backend()`.
- The `WATCH_LOCAL_WHISPER_BIN` env knob accepts either a name on PATH or an absolute path, mirroring how `WATCH_LOCAL_WHISPER_MODEL` works.
- I followed the existing "pure stdlib, no SDK" convention — no new pip deps, no new imports beyond what was already there.