### PR TITLE
fix: replace U+2192 arrows with ASCII dashes in focus-range output

### DIFF
--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -156,7 +156,7 @@ def main() -> int:
     print(f"- **Duration:** {format_time(full_duration)} ({full_duration:.1f}s)")
     if focused:
         print(
-            f"- **Focus range:** {format_time(effective_start)} → {format_time(effective_end)} "
+            f"- **Focus range:** {format_time(effective_start)} - {format_time(effective_end)} "
             f"({effective_duration:.1f}s)"
         )
     if meta.get("width") and meta.get("height"):
@@ -201,7 +201,7 @@ def main() -> int:
     if transcript_text:
         label = transcript_source or "captions"
         if focused:
-            print(f"_Source: {label}. Filtered to {format_time(effective_start)} → {format_time(effective_end)}:_")
+            print(f"_Source: {label}. Filtered to {format_time(effective_start)} - {format_time(effective_end)}:_")
         else:
             print(f"_Source: {label}._")
         print()
@@ -209,7 +209,7 @@ def main() -> int:
         print(transcript_text)
         print("```")
     elif focused and dl.get("subtitle_path"):
-        print(f"_No transcript lines fell inside {format_time(effective_start)} → {format_time(effective_end)}._")
+        print(f"_No transcript lines fell inside {format_time(effective_start)} - {format_time(effective_end)}._")
     else:
         setup_py = SCRIPT_DIR / "setup.py"
         print(


### PR DESCRIPTION
## Summary
Three `print(...)` lines in `scripts/watch.py` rendered focus-range labels using U+2192 RIGHTWARDS ARROW (`→`). The character isn't representable in Windows' default cp1252 console codepage and triggers `UnicodeEncodeError` — same class of issue as the emoji removal in v0.1.2 and the UTF-8 reads in v0.1.3.

Replaces `→` with ASCII `-` in:
- The `**Focus range:**` header line in the report
- The `_Source: ...:_` transcript label when `--start`/`--end` are set
- The `_No transcript lines fell inside ...:_` fallback when the filter returned nothing

ASCII hyphen renders cleanly across encodings and matches the `extracting … over <start>-<end>` separator the script already uses on stderr.

## Test plan
- [x] Local verification on Windows (cp1252 console): `python scripts/watch.py <url> --start 30 --end 60` no longer raises `UnicodeEncodeError` on the focus-range banner
- [ ] CI: existing release workflow still produces `dist/watch.skill` cleanly with the change
- [ ] Manual: confirm the report header and transcript labels look intentional with the dash separator

## Notes
Diff is 3 char swaps in 3 lines — surgical, no behavior change beyond the encoding fix. No version bump or CHANGELOG entry in this PR; happy to add either if you'd prefer to land this as a patch release vs. roll it into the next batch.