### PR TITLE
feat: long-video Whisper chunking and --no-frames flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `/watch` are documented here.
 
+## [Unreleased]
+
+### Added
+- Long-video support: audio over 22 MB (~45+ min) is now automatically split at silence boundaries (ffmpeg `silencedetect`, `-30dB` / `0.5s`) into ≤22 MB chunks, transcribed serially via Whisper, and restitched with timestamp offsets. Removes the previous ~52-minute upload ceiling. Adjacent identical-text segments at chunk boundaries are deduped to defend against Whisper's hallucinated start-of-clip artifact. Public `transcribe_video()` signature is unchanged.
+- `--no-frames` flag on `watch.py`: skip frame extraction entirely for audio-only content (podcasts, interviews, lectures). Symmetric to the existing `--no-whisper`.
+
 ## [0.1.3] — 2026-05-09
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -83,6 +83,7 @@ Optional flags:
 - `--out-dir DIR` — keep working files somewhere specific (default: an auto-generated tmp dir)
 - `--whisper groq|openai` — force a specific Whisper backend (default: prefer Groq if both keys exist)
 - `--no-whisper` — disable the Whisper fallback entirely (frames-only if no captions)
+- `--no-frames` — skip frame extraction entirely. Use for audio-only content (podcasts, interviews, lectures) where frames waste tokens. Transcript-only output.
 
 ### Focusing on a section (higher frame rate)
 
@@ -128,7 +129,7 @@ If the user asked a specific question, answer it directly citing timestamps. If 
 The script gets a timestamped transcript in one of two ways:
 
 1. **Native captions (free, preferred).** yt-dlp pulls manual or auto-generated subtitles from the source platform if available.
-2. **Whisper API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever Whisper API has a key configured:
+2. **Whisper API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever Whisper API has a key configured. Audio over 22 MB (roughly 45+ minutes) is automatically split at silence boundaries and transcribed serially before being restitched.
    - **Groq** — `whisper-large-v3`. Preferred default: cheaper, faster. Get a key at console.groq.com/keys.
    - **OpenAI** — `whisper-1`. Fallback. Get a key at platform.openai.com/api-keys.
 
@@ -140,7 +141,7 @@ Both keys live in `~/.config/watch/.env`. The script prefers Groq when both are 
 - **No transcript available** → captions missing AND (no Whisper key OR Whisper API failed). Script prints a hint pointing to setup. Proceed frames-only and tell the user.
 - **Long video warning printed** → acknowledge it in your answer. Offer to re-run focused on a specific section via `--start`/`--end` rather than a sparse full-video scan.
 - **Download fails** → yt-dlp's error goes to stderr. If it's a login-required or region-locked video, tell the user plainly; do not keep retrying.
-- **Whisper request fails** → the error is printed to stderr (likely: invalid key, rate limit, or 25 MB upload limit on a very long video). The report will say "none available" for transcript. You can retry with `--whisper openai` if Groq failed (or vice versa).
+- **Whisper request fails** → the error is printed to stderr (likely: invalid key or persistent rate-limit). The report will say "none available" for transcript. You can retry with `--whisper openai` if Groq failed (or vice versa). For videos over ~52 minutes, audio is automatically split at silence boundaries into ≤22 MB chunks before upload — no 25 MB ceiling to worry about, but a 2-hour video will take ~1 minute to transcribe across 3-4 sequential chunks.
 
 ## Token efficiency
 

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -39,6 +39,11 @@ def main() -> int:
         help="Disable Whisper fallback. Report frames-only if no captions available.",
     )
     ap.add_argument(
+        "--no-frames",
+        action="store_true",
+        help="Skip frame extraction. Useful for audio-only content (podcasts, interviews) — transcript-only output.",
+    )
+    ap.add_argument(
         "--whisper",
         choices=["groq", "openai"],
         default=None,
@@ -80,29 +85,35 @@ def main() -> int:
     effective_duration = max(0.0, effective_end - effective_start)
     focused = start_sec is not None or end_sec is not None
 
-    if focused:
-        fps, target = auto_fps_focus(effective_duration, max_frames=max_frames)
+    if args.no_frames:
+        fps = 0.0
+        target = 0
+        frames: list[dict] = []
+        print("[watch] --no-frames set — skipping frame extraction", file=sys.stderr)
     else:
-        fps, target = auto_fps(effective_duration, max_frames=max_frames)
-    if args.fps is not None:
-        fps = min(args.fps, MAX_FPS)
-        target = max(1, int(round(fps * effective_duration)))
+        if focused:
+            fps, target = auto_fps_focus(effective_duration, max_frames=max_frames)
+        else:
+            fps, target = auto_fps(effective_duration, max_frames=max_frames)
+        if args.fps is not None:
+            fps = min(args.fps, MAX_FPS)
+            target = max(1, int(round(fps * effective_duration)))
 
-    scope = (
-        f"{format_time(effective_start)}-{format_time(effective_end)} ({effective_duration:.1f}s)"
-        if focused else f"full {effective_duration:.1f}s"
-    )
-    print(f"[watch] extracting ~{target} frames at {fps:.3f} fps over {scope}…", file=sys.stderr)
+        scope = (
+            f"{format_time(effective_start)}-{format_time(effective_end)} ({effective_duration:.1f}s)"
+            if focused else f"full {effective_duration:.1f}s"
+        )
+        print(f"[watch] extracting ~{target} frames at {fps:.3f} fps over {scope}…", file=sys.stderr)
 
-    frames = extract(
-        video_path,
-        work / "frames",
-        fps=fps,
-        resolution=args.resolution,
-        max_frames=max_frames,
-        start_seconds=start_sec,
-        end_seconds=end_sec,
-    )
+        frames = extract(
+            video_path,
+            work / "frames",
+            fps=fps,
+            resolution=args.resolution,
+            max_frames=max_frames,
+            start_seconds=start_sec,
+            end_seconds=end_sec,
+        )
 
     transcript_segments: list[dict] = []
     transcript_text: str | None = None
@@ -161,9 +172,12 @@ def main() -> int:
         )
     if meta.get("width") and meta.get("height"):
         print(f"- **Resolution:** {meta['width']}x{meta['height']} ({meta.get('codec') or 'unknown codec'})")
-    mode = "focused" if focused else "full"
-    print(f"- **Frames:** {len(frames)} @ {fps:.3f} fps, {mode} mode (budget {target}, max {max_frames})")
-    print(f"- **Frame size:** {args.resolution}px wide")
+    if args.no_frames:
+        print("- **Frames:** skipped (`--no-frames`)")
+    else:
+        mode = "focused" if focused else "full"
+        print(f"- **Frames:** {len(frames)} @ {fps:.3f} fps, {mode} mode (budget {target}, max {max_frames})")
+        print(f"- **Frame size:** {args.resolution}px wide")
     if transcript_segments:
         in_range = " in range" if focused else ""
         print(
@@ -173,7 +187,7 @@ def main() -> int:
     else:
         print("- **Transcript:** none available")
 
-    if not focused and full_duration > 600:
+    if not focused and not args.no_frames and full_duration > 600:
         mins = int(full_duration // 60)
         print()
         print(
@@ -185,15 +199,18 @@ def main() -> int:
     print()
     print("## Frames")
     print()
-    print(f"Frames live at: `{work / 'frames'}`")
-    print()
-    print(
-        "**Read each frame path below with the Read tool to view the image.** "
-        "Frames are in chronological order; `t=MM:SS` is the absolute timestamp in the source video."
-    )
-    print()
-    for frame in frames:
-        print(f"- `{frame['path']}` (t={format_time(frame['timestamp_seconds'])})")
+    if args.no_frames:
+        print("_Skipped — `--no-frames` set._")
+    else:
+        print(f"Frames live at: `{work / 'frames'}`")
+        print()
+        print(
+            "**Read each frame path below with the Read tool to view the image.** "
+            "Frames are in chronological order; `t=MM:SS` is the absolute timestamp in the source video."
+        )
+        print()
+        for frame in frames:
+            print(f"- `{frame['path']}` (t={format_time(frame['timestamp_seconds'])})")
 
     print()
     print("## Transcript")

--- a/scripts/whisper.py
+++ b/scripts/whisper.py
@@ -14,6 +14,7 @@ import io
 import json
 import mimetypes
 import os
+import re
 import shutil
 import ssl
 import subprocess
@@ -30,6 +31,14 @@ GROQ_MODEL = "whisper-large-v3"
 
 OPENAI_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions"
 OPENAI_MODEL = "whisper-1"
+
+# Chunking: Whisper APIs (Groq + OpenAI) cap uploads at 25 MB. Above the
+# threshold we split at silence boundaries; the existing single-upload path
+# is preserved byte-for-byte for everything below it.
+WHISPER_CHUNK_THRESHOLD_MB = 22       # 3 MB headroom under the 25 MB server limit
+MIN_CHUNK_FLOOR_MB = 5                # don't let the greedy planner pick a tiny first chunk
+SILENCE_NOISE_DB = "-30dB"            # matches typical podcast/interview noise floor
+SILENCE_MIN_DURATION = 0.5            # natural sentence-pause length
 
 
 def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, None]:
@@ -83,7 +92,10 @@ def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, 
 
 
 def extract_audio(video_path: str, out_path: Path) -> Path:
-    """Extract mono 16kHz 64kbps mp3 — ~480 kB/min, fits any Whisper limit."""
+    """Extract mono 16kHz 64kbps mp3 — ~480 kB/min. Hits the 22 MB chunking
+    threshold around 46 min (server limit is 25 MB at ~52 min); the caller in
+    transcribe_video() splits at silences past the threshold.
+    """
     if shutil.which("ffmpeg") is None:
         raise SystemExit("ffmpeg is not installed. Install with: brew install ffmpeg")
 
@@ -107,6 +119,140 @@ def extract_audio(video_path: str, out_path: Path) -> Path:
     if not out_path.exists() or out_path.stat().st_size == 0:
         raise SystemExit("ffmpeg produced no audio — video may have no audio track")
     return out_path
+
+
+_SILENCE_START_RE = re.compile(r"silence_start:\s*(-?\d+(?:\.\d+)?)")
+
+
+def _audio_duration(audio_path: Path) -> float:
+    """Read the duration of an audio file in seconds via ffprobe."""
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v", "quiet",
+            "-show_entries", "format=duration",
+            "-of", "default=nw=1:nk=1",
+            str(audio_path.resolve()),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise SystemExit(f"ffprobe failed to read audio duration: {result.stderr.strip()}")
+    return float(result.stdout.strip())
+
+
+def _detect_silences(audio_path: Path) -> list[float]:
+    """Run ffmpeg's silencedetect filter; return ordered silence_start times (s).
+
+    Returns an empty list if ffmpeg fails — the caller falls back to byte-target
+    hard cuts, so a silencedetect failure degrades quality but doesn't abort
+    chunking. The failure is logged to stderr so the user sees the real cause.
+    """
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-nostats",
+        "-i", str(audio_path.resolve()),
+        "-af", f"silencedetect=noise={SILENCE_NOISE_DB}:duration={SILENCE_MIN_DURATION}",
+        "-f", "null",
+        "-",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        snippet = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else "(no stderr)"
+        print(
+            f"[watch] silencedetect failed (rc={result.returncode}): {snippet} — "
+            "falling back to byte-target cuts",
+            file=sys.stderr,
+        )
+        return []
+    silences: list[float] = []
+    for line in result.stderr.splitlines():
+        match = _SILENCE_START_RE.search(line)
+        if not match:
+            continue
+        try:
+            silences.append(float(match.group(1)))
+        except ValueError:
+            continue
+    silences.sort()
+    return silences
+
+
+def _chunk_audio(audio_path: Path) -> list[tuple[Path, float]]:
+    """Split audio at silence boundaries near a 22 MB target.
+
+    Returns [(chunk_path, offset_seconds), ...] in chronological order. Falls
+    back to hard byte-target cuts when no silence is available in the window —
+    the resulting segment around such a cut may be mid-word but the rest of
+    the transcript is unaffected.
+    """
+    file_size = audio_path.stat().st_size
+    duration_s = _audio_duration(audio_path)
+    if duration_s <= 0:
+        raise SystemExit("Audio file has zero duration — cannot chunk")
+
+    target_bytes = WHISPER_CHUNK_THRESHOLD_MB * 1024 * 1024
+    floor_bytes = MIN_CHUNK_FLOOR_MB * 1024 * 1024
+    bytes_per_sec = file_size / duration_s
+
+    silences = _detect_silences(audio_path)
+
+    cut_times: list[float] = []
+    cursor_bytes = 0
+    while file_size - cursor_bytes > target_bytes:
+        lo = cursor_bytes + floor_bytes
+        hi = cursor_bytes + target_bytes
+        # Latest silence inside the (lo, hi] byte window — maximises chunk size
+        # without exceeding the upload threshold.
+        best_t: float | None = None
+        for t in silences:
+            byte_off = t * bytes_per_sec
+            if byte_off <= lo:
+                continue
+            if byte_off > hi:
+                break
+            best_t = t  # keep iterating; we want the LAST candidate <= hi
+        if best_t is not None:
+            cut_bytes = best_t * bytes_per_sec
+            cut_t = best_t
+        else:
+            cut_bytes = cursor_bytes + target_bytes
+            cut_t = cut_bytes / bytes_per_sec
+        cut_times.append(cut_t)
+        cursor_bytes = int(cut_bytes)
+
+    chunks_dir = audio_path.parent / "audio_chunks"
+    chunks_dir.mkdir(parents=True, exist_ok=True)
+    for stale in chunks_dir.glob("chunk_*.mp3"):
+        stale.unlink()
+
+    boundaries = [0.0] + cut_times + [duration_s]
+    chunks: list[tuple[Path, float]] = []
+    for i in range(len(boundaries) - 1):
+        start = boundaries[i]
+        delta = boundaries[i + 1] - start
+        chunk_path = chunks_dir / f"chunk_{i:03d}.mp3"
+        cmd = [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel", "error",
+            "-y",
+            "-ss", f"{start:.3f}",
+            "-t", f"{delta:.3f}",
+            "-i", str(audio_path.resolve()),
+            "-c", "copy",
+            str(chunk_path.resolve()),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise SystemExit(f"ffmpeg chunk split failed at chunk {i}: {result.stderr.strip()}")
+        if not chunk_path.exists() or chunk_path.stat().st_size == 0:
+            raise SystemExit(f"chunk {i} produced no output")
+        chunks.append((chunk_path, start))
+
+    return chunks
 
 
 def _build_multipart(fields: dict[str, str], file_path: Path) -> tuple[bytes, str]:
@@ -284,19 +430,47 @@ def transcribe_video(
             f"Run `python3 {setup_py}` to configure."
         )
 
-    print(f"[watch] extracting audio for Whisper ({backend})…", file=sys.stderr)
-    audio_path = extract_audio(video_path, audio_out)
-    size_kb = audio_path.stat().st_size / 1024
-    print(f"[watch] audio: {size_kb:.0f} kB — uploading to {backend} Whisper…", file=sys.stderr)
-
     if backend == "groq":
-        response = _post_whisper(GROQ_ENDPOINT, api_key, GROQ_MODEL, audio_path)
+        endpoint, model = GROQ_ENDPOINT, GROQ_MODEL
     elif backend == "openai":
-        response = _post_whisper(OPENAI_ENDPOINT, api_key, OPENAI_MODEL, audio_path)
+        endpoint, model = OPENAI_ENDPOINT, OPENAI_MODEL
     else:
         raise SystemExit(f"Unknown whisper backend: {backend}")
 
-    segments = _segments_from_response(response)
+    print(f"[watch] extracting audio for Whisper ({backend})…", file=sys.stderr)
+    audio_path = extract_audio(video_path, audio_out)
+    size_kb = audio_path.stat().st_size / 1024
+    threshold_bytes = WHISPER_CHUNK_THRESHOLD_MB * 1024 * 1024
+
+    if audio_path.stat().st_size <= threshold_bytes:
+        print(f"[watch] audio: {size_kb:.0f} kB — uploading to {backend} Whisper…", file=sys.stderr)
+        response = _post_whisper(endpoint, api_key, model, audio_path)
+        segments = _segments_from_response(response)
+    else:
+        print(
+            f"[watch] audio: {size_kb:.0f} kB > {WHISPER_CHUNK_THRESHOLD_MB} MB — "
+            "splitting at silences before upload…",
+            file=sys.stderr,
+        )
+        chunks = _chunk_audio(audio_path)
+        print(f"[watch] chunked into {len(chunks)} pieces — transcribing serially…", file=sys.stderr)
+        segments = []
+        for i, (chunk_path, offset_s) in enumerate(chunks, 1):
+            chunk_kb = chunk_path.stat().st_size / 1024
+            print(
+                f"[watch] transcribing chunk {i}/{len(chunks)} ({chunk_kb:.0f} kB, "
+                f"offset {offset_s:.1f}s)…",
+                file=sys.stderr,
+            )
+            response = _post_whisper(endpoint, api_key, model, chunk_path)
+            for seg in _segments_from_response(response):
+                seg["start"] = round(seg["start"] + offset_s, 2)
+                seg["end"] = round(seg["end"] + offset_s, 2)
+                if segments and segments[-1]["text"] == seg["text"]:
+                    segments[-1]["end"] = seg["end"]
+                    continue
+                segments.append(seg)
+
     if not segments:
         raise SystemExit("Whisper returned no transcript segments")
 


### PR DESCRIPTION
## Summary

- **Whisper chunking for long videos.** Audio over 22 MB (~46 min at the current 64 kbps mono extract settings) is now split at silence boundaries via ffmpeg `silencedetect` (-30dB / 0.5s) and transcribed serially, then restitched with timestamp offsets. Removes the previous ~52-minute hard ceiling where Whisper rejected the upload as oversized. Adjacent identical-text segments at chunk boundaries are deduped to defend against Whisper''s hallucinated start-of-clip artifact. Public `transcribe_video()` signature is unchanged — `watch.py` and any downstream caller get longer-video support transparently.
- **`--no-frames` flag.** Symmetric to the existing `--no-whisper`. Skips frame extraction for audio-only content (podcasts, interviews, lectures) where frames waste tokens without adding signal. The long-video sparse-frames warning is suppressed in this mode since it''s irrelevant.

## Design notes (for fast review)

- **Threshold is size-based, not duration-based.** Triggered on the actual extracted-audio file size (22 MB, with 3 MB headroom under the 25 MB server limit). One source of truth that doesn''t drift if extract params change.
- **Serial chunk uploads, not parallel.** Groq''s free-tier rate limits make parallel uploads unreliable; the per-chunk retry logic in `_post_whisper` is designed for serial calls. ~60 s wall-clock for a 2 hr video.
- **Per-chunk failure aborts the whole job.** No gap placeholder. If one chunk fails (auth, persistent rate-limit, network), the others typically fail with the same root cause — a clear abort is more useful than a transcript with silent holes.
- **No CLI overrides for silence-detection params or chunk threshold.** Module-level constants (`SILENCE_NOISE_DB`, `SILENCE_MIN_DURATION`, `WHISPER_CHUNK_THRESHOLD_MB`, `MIN_CHUNK_FLOOR_MB`). Can be promoted to flags later if real-world recordings need it.
- **No overlap between chunks.** Clean silence cuts produce invisible joins; rare hard-cut fallback boundaries may garble one segment — accepted quality-vs-complexity trade.
- **Existing fast path is byte-for-byte unchanged.** Sub-22 MB audio still takes the original single-upload code path, same stderr output, same retries.
- **`silencedetect` ffmpeg failures are surfaced.** If `silencedetect` itself fails (e.g. unsupported codec), the underlying ffmpeg stderr is logged and chunking falls back to byte-target cuts, so the user sees the real cause instead of a misleading downstream "chunk split failed" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)