### PR TITLE
feat(watch): add --json output mode

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -83,6 +83,46 @@ Optional flags:
 - `--out-dir DIR` — keep working files somewhere specific (default: an auto-generated tmp dir)
 - `--whisper groq|openai` — force a specific Whisper backend (default: prefer Groq if both keys exist)
 - `--no-whisper` — disable the Whisper fallback entirely (frames-only if no captions)
+- `--json` — emit the full report as one JSON object on stdout instead of markdown (see "Structured output" below)
+
+### Structured output (`--json`)
+
+For wrapper skills or scripts that need to consume `/watch` output programmatically. When `--json` is set, stdout is a single JSON object replacing the markdown report. Status lines on stderr and exit codes are unchanged.
+
+Example (truncated):
+
+```json
+{
+  "schema_version": "1.0.0",
+  "source": { "kind": "url", "raw": "https://youtu.be/abc", "title": "...", "uploader": "...", "url": "...", "subtitle_path": null },
+  "video": { "path": "/tmp/watch-xyz/download/video.mp4", "duration_seconds": 123.4, "width": 1920, "height": 1080, "codec": "h264", "size_bytes": 12345678, "has_audio": true },
+  "focus": { "applied": false, "start_seconds": null, "end_seconds": null, "duration_seconds": null },
+  "frames": { "count": 80, "fps": 0.65, "target": 80, "max_frames": 80, "resolution_px": 512, "mode": "full", "items": [{ "index": 0, "timestamp_seconds": 0.0, "path": "/tmp/watch-xyz/frames/frame_0000.jpg" }] },
+  "transcript": { "source": "captions", "filtered_to_focus": false, "segments": [{ "start_seconds": 0.0, "end_seconds": 3.2, "text": "Welcome" }] },
+  "warnings": [],
+  "work_dir": "/tmp/watch-xyz"
+}
+```
+
+**Top-level keys:**
+
+| Key | Type | Meaning |
+|---|---|---|
+| `schema_version` | string | Semver. `"1.0.0"` today. |
+| `source` | object | Input source: `kind` (`"url"` \| `"file"`), `raw`, `url`, `title`, `uploader`, `subtitle_path`. |
+| `video` | object | File facts from ffprobe: `path`, `duration_seconds`, `width`, `height`, `codec`, `size_bytes`, `has_audio`. |
+| `focus` | object | Focus range: `applied`, `start_seconds`, `end_seconds`, `duration_seconds`. All nulls when `applied=false`. |
+| `frames` | object | `count`, `fps`, `target`, `max_frames`, `resolution_px`, `mode` (`"full"` \| `"focused"`), `items[]` with `index`, `timestamp_seconds`, `path`. |
+| `transcript` | object | `source` (`"captions"` \| `"whisper (groq)"` \| `"whisper (openai)"` \| `null`), `filtered_to_focus`, `segments[]` with `start_seconds`, `end_seconds`, `text`. |
+| `warnings` | array | Zero or more `{code, message}` items. Today: `code = "long_unfocused_video"` when an unfocused video is over 10 minutes. |
+| `work_dir` | string | Absolute path to the working directory (frames, downloaded video, transcript). |
+
+**Contract guarantees:**
+
+- Every documented key is always present. Missing data is `null` for scalars/objects and `[]` for arrays — never an omitted key.
+- All time fields use the `_seconds` suffix and contain non-negative floats. Sizes are bytes (int). Paths are absolute strings.
+- On failure, stdout is empty and the process exits non-zero. Diagnostics go to stderr in both modes.
+- Schema follows semver. Additive fields bump minor/patch; renames or removals bump major. A future major would be opt-in via a new flag.
 
 ### Focusing on a section (higher frame rate)
 

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -44,6 +44,11 @@ def main() -> int:
         default=None,
         help="Force a specific Whisper backend. Default: prefer Groq, fall back to OpenAI.",
     )
+    ap.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the full report as one JSON object on stdout instead of markdown.",
+    )
     args = ap.parse_args()
 
     max_frames = min(args.max_frames, 100)
@@ -144,6 +149,75 @@ def main() -> int:
             )
 
     info = dl.get("info") or {}
+
+    if args.json:
+        import json
+        long_unfocused = not focused and full_duration > 600
+        report = {
+            "schema_version": "1.0.0",
+            "source": {
+                "kind": "url" if is_url(args.source) else "file",
+                "raw": args.source,
+                "url": info.get("url") if is_url(args.source) else None,
+                "title": info.get("title"),
+                "uploader": info.get("uploader"),
+                "subtitle_path": dl.get("subtitle_path"),
+            },
+            "video": {
+                "path": str(video_path),
+                "duration_seconds": meta["duration_seconds"],
+                "width": meta.get("width"),
+                "height": meta.get("height"),
+                "codec": meta.get("codec"),
+                "size_bytes": meta["size_bytes"],
+                "has_audio": meta["has_audio"],
+            },
+            "focus": {
+                "applied": focused,
+                "start_seconds": effective_start if focused else None,
+                "end_seconds": effective_end if focused else None,
+                "duration_seconds": effective_duration if focused else None,
+            },
+            "frames": {
+                "count": len(frames),
+                "fps": fps,
+                "target": target,
+                "max_frames": max_frames,
+                "resolution_px": args.resolution,
+                "mode": "focused" if focused else "full",
+                "items": [
+                    {"index": f["index"], "timestamp_seconds": f["timestamp_seconds"], "path": f["path"]}
+                    for f in frames
+                ],
+            },
+            "transcript": {
+                "source": transcript_source,
+                "filtered_to_focus": bool(focused and transcript_segments),
+                "segments": [
+                    {"start_seconds": s["start"], "end_seconds": s["end"], "text": s["text"]}
+                    for s in transcript_segments
+                ],
+            },
+            "warnings": (
+                [{
+                    "code": "long_unfocused_video",
+                    "message": (
+                        f"This is a {int(full_duration // 60)}-minute video. Frame coverage is sparse "
+                        "at this length — accuracy degrades noticeably on anything over 10 minutes. "
+                        "For better results, re-run with `--start HH:MM:SS --end HH:MM:SS` to zoom "
+                        "into a specific section."
+                    ),
+                }]
+                if long_unfocused
+                else []
+            ),
+            "work_dir": str(work),
+        }
+        sys.stdout.buffer.write(
+            (json.dumps(report, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+        )
+        sys.stdout.flush()
+        return 0
 
     print()
     print("# watch: video report")


### PR DESCRIPTION
## Summary

Adds an opt-in `--json` flag to `scripts/watch.py` that emits the full
report as one JSON object on stdout in place of the markdown report.
Unblocks wrapper skills and scripts that consume `/watch` programmatically.
The `--json` pattern is already established in this repo via
`setup.py --json` ([SKILL.md:47](https://github.com/bradautomates/claude-video/blob/main/SKILL.md#L47)).

The schema is locked at v1.0.0 (semver) as a public contract — additive
fields bump minor/patch; renames or removals bump major. Every documented
key is always present (`null` for scalars/objects, `[]` for arrays, never
an omitted key) so consumers don't need defensive accessors. Time fields
use the `_seconds` suffix; sizes are bytes; paths absolute. Full schema
is documented in the new SKILL.md section.

Design choices worth flagging:

- JSON-only when `--json` is set (no augment-with-markdown). Cleaner
  consumer contract; no delimiter or two output paths to keep in sync.
- Segments-only transcript (no pre-formatted `[MM:SS] text` blob) — single
  source of truth; consumers re-format if needed.
- Writes UTF-8 bytes to `sys.stdout.buffer` directly. On Windows the
  default `sys.stdout` encoder is cp1252 and crashes on em-dashes or
  non-ASCII titles; this bypasses the issue portably.
- Failure path unchanged: stderr + non-zero exit, stdout empty. Wrappers
  branch on exit code first.

## Compatibility

- Markdown branch is byte-identical pre/post when `--json` is absent.
- No new dependencies. No changes to argparse defaults or stderr behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
