### PR TITLE
Fix UnicodeEncodeError on Windows when video titles contain emoji

### DIFF
--- a/skills/watch/scripts/watch.py
+++ b/skills/watch/scripts/watch.py
@@ -12,6 +12,17 @@ import tempfile
 from pathlib import Path
 
 
+# Windows stdout/stderr default to the locale code page (cp1252), which raises
+# UnicodeEncodeError on emoji / non-Latin-1 characters in video titles and
+# aborts the report. Force UTF-8 so the report (and frame paths) always print.
+# Guarded in case the streams don't support reconfigure().
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, ValueError):
+        pass
+
+
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR))
 


### PR DESCRIPTION
## Problem

On Windows, Python's stdout/stderr default to the locale code page (typically cp1252). When a video title contains emoji or any character outside that code page, printing the report raises `UnicodeEncodeError` and `watch.py` exits 1 — **after** the download, frame extraction, and transcription have already succeeded. The frame paths are never printed, so the whole run is lost.

Emoji in titles are common on YouTube, so on a default Windows setup this breaks a large share of videos.

## Repro (Windows, e.g. German locale / cp1252)

```
python scripts/watch.py https://www.youtube.com/watch?v=pl3n9o_ZR9M
```

```
File "...\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f92f' in position 41: character maps to <undefined>
```

(The title is `Anfängerin überrascht ALLE! 🤯 Angeln lernen von A bis Z 🎣` — the 🤯 kills the report.)

## Fix

Reconfigure `sys.stdout`/`sys.stderr` to UTF-8 with `errors="replace"` at startup of the entry point. This is a no-op on macOS/Linux (streams are UTF-8 already) and is guarded with try/except for exotic streams that don't support `reconfigure()`.

Since `watch.py` imports all other modules into the same process, this covers the whole pipeline.

## Verification

On Windows 11 (cp1252 console):
- Before: the repro above crashes with exit 1.
- After: the same command prints the full report including the emoji title, exit 0.
- `python -c "print('🤯')"` still crashes in the same shell, confirming the environment itself reproduces the bug and the fix is what resolves it.

Complements #4, which fixed the same class of issue for config file I/O.

---
**Update:** Rebased onto the `skills/watch/` restructure (0.2.0). Fix itself is unchanged. Confirmed the full pytest suite gives identical pass/fail counts with and without this change (a handful of local failures are a pre-existing Windows/ffmpeg subprocess environment issue, unrelated to this patch).