### PR TITLE
Add Deepgram backend: transcribe audio over Whisper's 25 MB limit (45 min+ videos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Claude is great at reading and synthesizing — but until now, video was the one
 1. **You paste a video and a question.** URL (anything yt-dlp supports — YouTube, Loom, TikTok, X, Instagram, plus a few hundred more) or a local path (`.mp4`, `.mov`, `.mkv`, `.webm`).
 2. **`yt-dlp` downloads it.** For URLs, into a temp working directory. For local files, no download — just probed in place.
 3. **`ffmpeg` extracts frames at an auto-scaled rate.** The frame budget is duration-aware: ≤30s gets ~30 frames, 30-60s gets ~40, 1-3min gets ~60, 3-10min gets ~80, longer gets 100 sparsely. Hard ceilings: 2 fps, 100 frames. JPEGs at 512px wide by default — bump with `--resolution 1024` if Claude needs to read on-screen text.
-4. **The transcript comes from one of two places.** First try: `yt-dlp` pulls native captions (manual or auto-generated) from the source. Free, instant, accurate-ish. Fallback: extract a mono 16 kHz audio clip and ship it to Whisper — Groq's `whisper-large-v3` (preferred — cheaper and faster) or OpenAI's `whisper-1`.
+4. **The transcript comes from one of three places.** First try: `yt-dlp` pulls native captions (manual or auto-generated) from the source. Free, instant, accurate-ish. Fallback: extract a mono 16 kHz audio clip and ship it to Whisper — Groq's `whisper-large-v3` (preferred — cheaper and faster) or OpenAI's `whisper-1`. Both cap uploads at 25 MB (~45 min of audio); past that — or when it's the only key you have — the clip goes to Deepgram's `nova-2` instead, which takes files up to ~2 GB.
 5. **Frames + transcript are handed to Claude.** The script prints frame paths with `t=MM:SS` markers and the transcript with timestamps. Claude `Read`s each frame in parallel — JPEGs render directly as images in its context.
 6. **Claude answers grounded in what's actually on screen and in the audio.** Not "based on the description" or "according to the title." It saw the frames. It heard the transcript. It answers the way someone who watched the video would.
 7. **Cleanup.** The script prints a working directory at the end. If you're not asking follow-ups, Claude removes it.
@@ -112,7 +112,7 @@ On the first `/watch` call, the skill runs `scripts/setup.py --check`. If `ffmpe
 - **macOS** — auto-runs `brew install ffmpeg yt-dlp`.
 - **Linux** — prints the exact `apt` / `dnf` / `pipx` commands.
 - **Windows** — prints the `winget` / `pip` commands.
-- **API key** — scaffolds `~/.config/watch/.env` (mode `0600`) with commented placeholders for `GROQ_API_KEY` (preferred) and `OPENAI_API_KEY`.
+- **API key** — scaffolds `~/.config/watch/.env` (mode `0600`) with commented placeholders for `GROQ_API_KEY` (preferred), `OPENAI_API_KEY`, and `DEEPGRAM_API_KEY` (for audio over Whisper's 25 MB limit, or standalone).
 
 After setup, preflight is silent and `/watch` just works. The check is a sub-100ms lookup, so it doesn't slow you down on subsequent runs.
 
@@ -125,7 +125,8 @@ Captions cover the majority of public videos for free. The Whisper fallback only
 | Download + native captions | `yt-dlp` + `ffmpeg` | Free |
 | Whisper fallback (preferred) | [Groq API key](https://console.groq.com/keys) — `whisper-large-v3` | Cheap, fast |
 | Whisper fallback (alt) | [OpenAI API key](https://platform.openai.com/api-keys) — `whisper-1` | Standard pricing |
-| Disable Whisper entirely | `--no-whisper` | Free, frames-only when no captions |
+| Long videos (45 min+) / standalone | [Deepgram API key](https://console.deepgram.com) — `nova-2`, no 25 MB limit | Standard pricing |
+| Disable transcription entirely | `--no-whisper` | Free, frames-only when no captions |
 
 ## Usage
 
@@ -148,7 +149,7 @@ Other knobs (passed to `scripts/watch.py`):
 - `--max-frames N` — lower the frame cap for a tighter token budget.
 - `--resolution W` — bump frame width to 1024 px when Claude needs to read on-screen text (slides, terminals, code).
 - `--fps F` — override the auto-fps calculation (still capped at 2 fps).
-- `--whisper groq|openai` — force a specific Whisper backend.
+- `--whisper groq|openai|deepgram` — force a specific transcription backend.
 - `--no-whisper` — disable transcription entirely; frames only.
 - `--out-dir DIR` — keep working files somewhere specific (default: auto-generated tmp dir).
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -81,7 +81,7 @@ Optional flags:
 - `--resolution W` — change frame width in px (default 512; bump to 1024 only if the user needs to read on-screen text)
 - `--fps F` — override auto-fps (clamped to 2 fps max)
 - `--out-dir DIR` — keep working files somewhere specific (default: an auto-generated tmp dir)
-- `--whisper groq|openai` — force a specific Whisper backend (default: prefer Groq if both keys exist)
+- `--whisper groq|openai|deepgram` — force a specific transcription backend (default: prefer Groq if multiple keys exist; Deepgram auto-handles audio over 25 MB)
 - `--no-whisper` — disable the Whisper fallback entirely (frames-only if no captions)
 
 ### Focusing on a section (higher frame rate)
@@ -125,14 +125,16 @@ If the user asked a specific question, answer it directly citing timestamps. If 
 
 ## Transcription
 
-The script gets a timestamped transcript in one of two ways:
+The script gets a timestamped transcript in one of three ways:
 
 1. **Native captions (free, preferred).** yt-dlp pulls manual or auto-generated subtitles from the source platform if available.
 2. **Whisper API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever Whisper API has a key configured:
    - **Groq** — `whisper-large-v3`. Preferred default: cheaper, faster. Get a key at console.groq.com/keys.
    - **OpenAI** — `whisper-1`. Fallback. Get a key at platform.openai.com/api-keys.
+   - **Size limit:** Groq and OpenAI both reject uploads over **25 MB** (HTTP 413) — roughly **45+ minutes** of audio at 64 kbps. Past that, Whisper can't be used.
+3. **Deepgram.** Routes to Deepgram's pre-recorded API (`nova-2`, `utterances=true`, `detect_language=true`), which has no practical size limit (~2 GB). Used automatically when the extracted audio exceeds ~24 MB or when Whisper fails — and works **standalone** as the primary backend when `DEEPGRAM_API_KEY` is the only key configured. Get a key at console.deepgram.com.
 
-Both keys live in `~/.config/watch/.env`. The script prefers Groq when both are set; override with `--whisper openai` to force OpenAI. Use `--no-whisper` to skip the fallback entirely.
+All keys live in `~/.config/watch/.env`. The script prefers Groq when set; override with `--whisper openai` or `--whisper deepgram` to force a backend. Audio over 24 MB auto-routes to Deepgram if a `DEEPGRAM_API_KEY` is present, so long videos transcribe end-to-end. Use `--no-whisper` to skip the audio-transcription fallback entirely (captions only).
 
 ## Failure modes and handling
 
@@ -140,7 +142,7 @@ Both keys live in `~/.config/watch/.env`. The script prefers Groq when both are 
 - **No transcript available** → captions missing AND (no Whisper key OR Whisper API failed). Script prints a hint pointing to setup. Proceed frames-only and tell the user.
 - **Long video warning printed** → acknowledge it in your answer. Offer to re-run focused on a specific section via `--start`/`--end` rather than a sparse full-video scan.
 - **Download fails** → yt-dlp's error goes to stderr. If it's a login-required or region-locked video, tell the user plainly; do not keep retrying.
-- **Whisper request fails** → the error is printed to stderr (likely: invalid key, rate limit, or 25 MB upload limit on a very long video). The report will say "none available" for transcript. You can retry with `--whisper openai` if Groq failed (or vice versa).
+- **Whisper request fails** → the error is printed to stderr (likely: invalid key or rate limit; audio over 25 MB auto-routes to Deepgram when a key is set). The report will say "none available" for transcript. You can retry with `--whisper openai` if Groq failed (or vice versa), or `--whisper deepgram` to bypass Whisper entirely.
 
 ## Token efficiency
 
@@ -158,6 +160,7 @@ If you already watched a video this session and the user asks a follow-up, do **
 - Runs `ffmpeg` / `ffprobe` locally to extract frames as JPEGs and, when Whisper is needed, a mono 16 kHz audio clip
 - Sends the extracted audio clip to Groq's Whisper API (`api.groq.com/openai/v1/audio/transcriptions`) when `GROQ_API_KEY` is set (preferred — cheaper, faster)
 - Sends the extracted audio clip to OpenAI's audio transcription API (`api.openai.com/v1/audio/transcriptions`) when `OPENAI_API_KEY` is set and Groq is not, or when `--whisper openai` is forced
+- Sends the extracted audio clip to Deepgram's pre-recorded API (`api.deepgram.com/v1/listen`) when `DEEPGRAM_API_KEY` is set and the audio is too large for Whisper's 25 MB limit (or Whisper otherwise failed)
 - Writes the downloaded video, frames, audio, and an intermediate transcript to a working directory under the system temp dir (or `--out-dir` if specified) so Claude can `Read` them
 - Reads / creates `~/.config/watch/.env` (mode `0600`) to store the Whisper API key(s) and a `SETUP_COMPLETE` marker. As a fallback, also reads `.env` in the current working directory
 

--- a/scripts/deepgram_backend.py
+++ b/scripts/deepgram_backend.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Transcribe an audio file via the Deepgram pre-recorded API.
+
+Used as a large-file fallback for the Whisper path: Groq and OpenAI both cap
+uploads at 25 MB, so audio from long videos (~45 min+ at 64 kbps) gets rejected
+with HTTP 413. Deepgram's pre-recorded endpoint accepts files up to ~2 GB and
+returns utterance-level timestamps, which map directly onto our {start, end,
+text} segment shape.
+
+Pure stdlib — no `pip install deepgram-sdk` / `httpx`. Named `deepgram_backend`
+(not `deepgram`) so it never shadows or gets shadowed by the real Deepgram SDK
+if that happens to be installed in the same environment.
+"""
+from __future__ import annotations
+
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+
+DEEPGRAM_ENDPOINT = "https://api.deepgram.com/v1/listen"
+DEEPGRAM_MODEL = "nova-2"
+
+# Query options. nova-2 with detect_language keeps this language-agnostic (the
+# /watch skill is general-purpose, not German-only). utterances gives clean
+# timestamped chunks; smart_format + punctuate make the text readable.
+DEEPGRAM_PARAMS = {
+    "model": DEEPGRAM_MODEL,
+    "smart_format": "true",
+    "punctuate": "true",
+    "utterances": "true",
+    "detect_language": "true",
+}
+
+
+def load_deepgram_key() -> str | None:
+    """Read DEEPGRAM_API_KEY from the environment or the watch .env files."""
+    value = os.environ.get("DEEPGRAM_API_KEY")
+    if value and value.strip():
+        return value.strip()
+
+    dotenv_paths = [
+        Path.home() / ".config" / "watch" / ".env",
+        Path.cwd() / ".env",
+    ]
+    for path in dotenv_paths:
+        if not path.exists():
+            continue
+        try:
+            for line in path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, raw = line.partition("=")
+                if key.strip() != "DEEPGRAM_API_KEY":
+                    continue
+                raw = raw.strip()
+                if len(raw) >= 2 and raw[0] in ('"', "'") and raw[-1] == raw[0]:
+                    raw = raw[1:-1]
+                if raw:
+                    return raw
+        except OSError:
+            continue
+    return None
+
+
+def _mimetype(audio_path: Path) -> str:
+    ext = audio_path.suffix.lower()
+    return {
+        ".mp3": "audio/mpeg",
+        ".wav": "audio/wav",
+        ".m4a": "audio/mp4",
+        ".aac": "audio/aac",
+        ".ogg": "audio/ogg",
+        ".opus": "audio/opus",
+        ".flac": "audio/flac",
+    }.get(ext, "audio/mpeg")
+
+
+def _segments_from_response(data: dict) -> list[dict]:
+    """Convert a Deepgram response into our {start, end, text} segment list.
+
+    Prefer utterances (already chunked with timestamps); fall back to
+    paragraph sentences, then to the flat transcript with a single segment.
+    """
+    results = (data or {}).get("results") or {}
+
+    out: list[dict] = []
+    for utt in results.get("utterances") or []:
+        text = str(utt.get("transcript") or "").strip()
+        if not text:
+            continue
+        out.append({
+            "start": round(float(utt.get("start") or 0.0), 2),
+            "end": round(float(utt.get("end") or 0.0), 2),
+            "text": text,
+        })
+    if out:
+        return out
+
+    channels = results.get("channels") or []
+    alts = (channels[0].get("alternatives") if channels else None) or []
+    alt = alts[0] if alts else {}
+
+    paragraphs = ((alt.get("paragraphs") or {}).get("paragraphs")) or []
+    for para in paragraphs:
+        sentences = para.get("sentences") or []
+        text = " ".join(str(s.get("text") or "").strip() for s in sentences).strip()
+        if not text:
+            continue
+        out.append({
+            "start": round(float(para.get("start") or 0.0), 2),
+            "end": round(float(para.get("end") or 0.0), 2),
+            "text": text,
+        })
+    if out:
+        return out
+
+    full = str(alt.get("transcript") or "").strip()
+    if full:
+        out.append({"start": 0.0, "end": 0.0, "text": full})
+    return out
+
+
+def transcribe_deepgram(audio_path: Path, api_key: str) -> list[dict]:
+    """Upload audio to Deepgram and return {start, end, text} segments.
+
+    Raises SystemExit on any hard failure so the caller can fall through or
+    report frames-only, matching the Whisper path's contract.
+    """
+    audio_path = Path(audio_path)
+    if not audio_path.exists() or audio_path.stat().st_size == 0:
+        raise SystemExit(f"Deepgram: audio file missing or empty: {audio_path}")
+
+    url = f"{DEEPGRAM_ENDPOINT}?{urllib.parse.urlencode(DEEPGRAM_PARAMS)}"
+    headers = {
+        "Authorization": f"Token {api_key}",
+        "Content-Type": _mimetype(audio_path),
+    }
+    body = audio_path.read_bytes()
+    context = ssl.create_default_context()
+
+    request = Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urlopen(request, timeout=600, context=context) as response:
+            payload = response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = f" — {exc.read().decode('utf-8', errors='replace')[:400]}"
+        except Exception:
+            pass
+        raise SystemExit(f"Deepgram request failed: {exc}{detail}")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise SystemExit(f"Deepgram network error: {type(exc).__name__}: {exc}")
+
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Deepgram returned non-JSON response: {exc}: {payload[:200]}")
+
+    segments = _segments_from_response(data)
+    if not segments:
+        raise SystemExit("Deepgram returned no transcript segments")
+    return segments
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: deepgram_backend.py <audio-path>", file=sys.stderr)
+        raise SystemExit(2)
+
+    key = load_deepgram_key()
+    if not key:
+        print("No DEEPGRAM_API_KEY found (env or ~/.config/watch/.env)", file=sys.stderr)
+        raise SystemExit(3)
+
+    segs = transcribe_deepgram(Path(sys.argv[1]), key)
+    print(json.dumps({"backend": "deepgram", "segments": segs}, indent=2, ensure_ascii=False))

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -41,11 +41,16 @@ ENV_TEMPLATE = """# /watch API configuration
 # Get a Groq key:  https://console.groq.com/keys
 # Get an OpenAI key:  https://platform.openai.com/api-keys
 #
-# Leave both blank to disable Whisper — /watch will still work, but videos
-# without native captions will come back frames-only.
+# Deepgram is optional: it handles audio over Whisper's 25 MB upload limit
+# (videos longer than ~45 minutes) and also works standalone as the only key.
+# Get a Deepgram key:  https://console.deepgram.com
+#
+# Leave all blank to disable transcription — /watch will still work, but
+# videos without native captions will come back frames-only.
 
 GROQ_API_KEY=
 OPENAI_API_KEY=
+DEEPGRAM_API_KEY=
 """
 
 
@@ -100,6 +105,8 @@ def _have_api_key() -> tuple[bool, str | None]:
         return True, "groq"
     if _read_env_key("OPENAI_API_KEY"):
         return True, "openai"
+    if _read_env_key("DEEPGRAM_API_KEY"):
+        return True, "deepgram"
     return False, None
 
 
@@ -238,7 +245,7 @@ def cmd_check() -> int:
     if s["missing_binaries"]:
         parts.append(f"missing binaries: {', '.join(s['missing_binaries'])}")
     if not s["has_api_key"]:
-        parts.append("no Whisper API key (GROQ_API_KEY or OPENAI_API_KEY)")
+        parts.append("no transcription API key (GROQ_API_KEY, OPENAI_API_KEY, or DEEPGRAM_API_KEY)")
     installer = Path(__file__).resolve()
     sys.stderr.write(
         f"[watch] setup incomplete ({'; '.join(parts)}). "
@@ -302,11 +309,12 @@ def cmd_install() -> int:
         return 0
 
     print("")
-    print("[setup] one step left: add a Whisper API key.")
+    print("[setup] one step left: add a transcription API key.")
     print("")
-    print(f"  Edit {CONFIG_FILE} and set either:")
-    print("    GROQ_API_KEY=...    (preferred — cheaper, faster; get one at console.groq.com/keys)")
-    print("    OPENAI_API_KEY=...  (fallback; get one at platform.openai.com/api-keys)")
+    print(f"  Edit {CONFIG_FILE} and set one of:")
+    print("    GROQ_API_KEY=...      (preferred — cheaper, faster; get one at console.groq.com/keys)")
+    print("    OPENAI_API_KEY=...    (fallback; get one at platform.openai.com/api-keys)")
+    print("    DEEPGRAM_API_KEY=...  (handles audio over Whisper's 25 MB limit; console.deepgram.com)")
     print("")
     print("  Without a key, /watch still works but videos without captions come back frames-only.")
     return 3

--- a/scripts/watch.py
+++ b/scripts/watch.py
@@ -19,6 +19,7 @@ from download import download, is_url  # noqa: E402
 from frames import MAX_FPS, auto_fps, auto_fps_focus, extract, format_time, get_metadata, parse_time  # noqa: E402
 from transcribe import filter_range, format_transcript, parse_vtt  # noqa: E402
 from whisper import load_api_key, transcribe_video  # noqa: E402
+from deepgram_backend import load_deepgram_key  # noqa: E402
 
 
 def main() -> int:
@@ -40,9 +41,12 @@ def main() -> int:
     )
     ap.add_argument(
         "--whisper",
-        choices=["groq", "openai"],
+        choices=["groq", "openai", "deepgram"],
         default=None,
-        help="Force a specific Whisper backend. Default: prefer Groq, fall back to OpenAI.",
+        help=(
+            "Force a specific transcription backend. Default: prefer Groq, fall back "
+            "to OpenAI; Deepgram is used for audio over 25 MB or when it holds the only key."
+        ),
     )
     args = ap.parse_args()
 
@@ -117,29 +121,37 @@ def main() -> int:
             print(f"[watch] subtitle parse failed: {exc}", file=sys.stderr)
 
     if not transcript_segments and not args.no_whisper:
-        backend, api_key = load_api_key(args.whisper)
-        if backend and api_key:
+        deepgram_key = load_deepgram_key()
+        if args.whisper == "deepgram":
+            # Forced Deepgram: skip Whisper key detection entirely.
+            backend, api_key = ("deepgram", None) if deepgram_key else (None, None)
+        else:
+            backend, api_key = load_api_key(args.whisper)
+        if (backend and api_key) or deepgram_key:
             try:
                 all_segments, used_backend = transcribe_video(
                     video_path,
                     work / "audio.mp3",
                     backend=backend,
                     api_key=api_key,
+                    deepgram_key=deepgram_key,
                 )
                 transcript_segments = filter_range(all_segments, start_sec, end_sec) if focused else all_segments
                 transcript_text = format_transcript(transcript_segments)
-                transcript_source = f"whisper ({used_backend})"
+                transcript_source = (
+                    "deepgram" if used_backend == "deepgram" else f"whisper ({used_backend})"
+                )
             except SystemExit as exc:
-                print(f"[watch] whisper fallback failed: {exc}", file=sys.stderr)
+                print(f"[watch] transcription fallback failed: {exc}", file=sys.stderr)
         else:
             hint = (
                 f"--whisper {args.whisper} was set but the matching API key is missing"
                 if args.whisper else
-                "no subtitles and no Whisper API key found"
+                "no subtitles and no transcription API key found"
             )
             setup_py = SCRIPT_DIR / "setup.py"
             print(
-                f"[watch] {hint} — run `python3 {setup_py}` to enable the Whisper fallback",
+                f"[watch] {hint} — run `python3 {setup_py}` to enable the transcript fallback",
                 file=sys.stderr,
             )
 

--- a/scripts/whisper.py
+++ b/scripts/whisper.py
@@ -24,12 +24,19 @@ import uuid
 from pathlib import Path
 from urllib.request import Request, urlopen
 
+from deepgram_backend import load_deepgram_key, transcribe_deepgram
+
 
 GROQ_ENDPOINT = "https://api.groq.com/openai/v1/audio/transcriptions"
 GROQ_MODEL = "whisper-large-v3"
 
 OPENAI_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions"
 OPENAI_MODEL = "whisper-1"
+
+# Groq and OpenAI both reject uploads larger than 25 MB (HTTP 413). Above this
+# threshold we route straight to Deepgram (no practical size limit) when a key
+# is configured. 24 MB leaves headroom under the hard 25 MB cap.
+WHISPER_MAX_MB = 24.0
 
 
 def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, None]:
@@ -266,47 +273,103 @@ def transcribe_video(
     audio_out: Path,
     backend: str | None = None,
     api_key: str | None = None,
+    deepgram_key: str | None = None,
 ) -> tuple[list[dict], str]:
     """Run the full flow: extract audio → upload → parse segments.
 
-    Returns (segments, backend_used). Raises SystemExit on any failure.
+    Routing:
+      - backend == "deepgram": Deepgram only, regardless of audio size or
+        other configured keys.
+      - Audio <= 24 MB: try Whisper (Groq/OpenAI); on failure fall back to
+        Deepgram if a key is available. With no Whisper key, Deepgram is the
+        primary backend.
+      - Audio > 24 MB: route straight to Deepgram (Whisper would 413). With no
+        Deepgram key, attempt Whisper anyway so the user gets a clear error.
+
+    Returns (segments, backend_used) where backend_used is "groq", "openai",
+    or "deepgram". Raises SystemExit if every available backend fails.
     """
-    if backend is None or api_key is None:
+    if deepgram_key is None:
+        deepgram_key = load_deepgram_key()
+
+    if backend == "deepgram":
+        if not deepgram_key:
+            raise SystemExit(
+                "Deepgram backend requested but no DEEPGRAM_API_KEY is configured. "
+                "Set it in the environment or in ~/.config/watch/.env."
+            )
+        backend, api_key = None, None  # skip the Whisper path entirely
+    elif backend is None or api_key is None:
         detected_backend, detected_key = load_api_key()
         backend = backend or detected_backend
         api_key = api_key or detected_key
 
-    if not backend or not api_key:
+    have_whisper = bool(backend and api_key)
+    if not have_whisper and not deepgram_key:
         setup_py = Path(__file__).resolve().parent / "setup.py"
         raise SystemExit(
-            "No Whisper API key available. Set GROQ_API_KEY (preferred) or OPENAI_API_KEY "
-            "in the environment or in ~/.config/watch/.env. "
+            "No transcription API key available. Set GROQ_API_KEY (preferred) or "
+            "OPENAI_API_KEY for Whisper, or DEEPGRAM_API_KEY for large files, in the "
+            "environment or in ~/.config/watch/.env. "
             f"Run `python3 {setup_py}` to configure."
         )
 
-    print(f"[watch] extracting audio for Whisper ({backend})…", file=sys.stderr)
+    print("[watch] extracting audio for transcription…", file=sys.stderr)
     audio_path = extract_audio(video_path, audio_out)
-    size_kb = audio_path.stat().st_size / 1024
-    print(f"[watch] audio: {size_kb:.0f} kB — uploading to {backend} Whisper…", file=sys.stderr)
+    size_mb = audio_path.stat().st_size / (1024 * 1024)
+    print(f"[watch] audio: {size_mb:.1f} MB", file=sys.stderr)
 
-    if backend == "groq":
-        response = _post_whisper(GROQ_ENDPOINT, api_key, GROQ_MODEL, audio_path)
-    elif backend == "openai":
-        response = _post_whisper(OPENAI_ENDPOINT, api_key, OPENAI_MODEL, audio_path)
-    else:
-        raise SystemExit(f"Unknown whisper backend: {backend}")
+    too_big_for_whisper = size_mb > WHISPER_MAX_MB
+    errors: list[str] = []
 
-    segments = _segments_from_response(response)
-    if not segments:
-        raise SystemExit("Whisper returned no transcript segments")
+    # Whisper first, unless the file is too big AND Deepgram can take it instead.
+    if have_whisper and not (too_big_for_whisper and deepgram_key):
+        if too_big_for_whisper:
+            print(
+                f"[watch] audio is {size_mb:.1f} MB (> 25 MB Whisper limit) and no "
+                f"Deepgram key set — attempting {backend} anyway…",
+                file=sys.stderr,
+            )
+        try:
+            if backend == "groq":
+                response = _post_whisper(GROQ_ENDPOINT, api_key, GROQ_MODEL, audio_path)
+            elif backend == "openai":
+                response = _post_whisper(OPENAI_ENDPOINT, api_key, OPENAI_MODEL, audio_path)
+            else:
+                raise SystemExit(f"Unknown whisper backend: {backend}")
+            segments = _segments_from_response(response)
+            if segments:
+                print(f"[watch] transcribed {len(segments)} segments via {backend}", file=sys.stderr)
+                return segments, backend
+            errors.append(f"{backend}: returned no segments")
+        except SystemExit as exc:
+            errors.append(f"{backend}: {exc}")
+            if not deepgram_key:
+                raise
+            print(f"[watch] {backend} Whisper failed — falling back to Deepgram", file=sys.stderr)
+    elif have_whisper and too_big_for_whisper and deepgram_key:
+        print(
+            f"[watch] audio is {size_mb:.1f} MB — over Whisper's 25 MB limit; "
+            "routing to Deepgram",
+            file=sys.stderr,
+        )
 
-    print(f"[watch] transcribed {len(segments)} segments via {backend}", file=sys.stderr)
-    return segments, backend
+    # Deepgram fallback (or primary, when it's the only key configured).
+    if deepgram_key:
+        print("[watch] uploading to Deepgram (nova-2)…", file=sys.stderr)
+        try:
+            segments = transcribe_deepgram(audio_path, deepgram_key)
+            print(f"[watch] transcribed {len(segments)} segments via deepgram", file=sys.stderr)
+            return segments, "deepgram"
+        except SystemExit as exc:
+            errors.append(f"deepgram: {exc}")
+
+    raise SystemExit("transcription failed — " + "; ".join(errors))
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("usage: whisper.py <video-path> [<audio-out.mp3>] [--backend groq|openai]", file=sys.stderr)
+        print("usage: whisper.py <video-path> [<audio-out.mp3>] [--backend groq|openai|deepgram]", file=sys.stderr)
         raise SystemExit(2)
 
     video = sys.argv[1]


### PR DESCRIPTION
## Problem

Groq and OpenAI Whisper both reject uploads over **25 MB** with HTTP 413. At the 64 kbps mono extraction rate that's roughly **45 minutes of audio** — so any longer caption-less video currently comes back frames-only, with no transcript possible at all:

```
[watch] audio: 27625 kB — uploading to groq Whisper…
[watch] whisper fallback failed: Whisper request failed: HTTP Error 413: Payload Too Large
       — {"error":{"message":"Request Entity Too Large",...,"code":"request_too_large"}}
```

This bites in practice: long tutorials, podcasts, talks, VODs — and YouTube caption pulls can also fail with 429 rate limits, which makes the audio fallback the only path for those videos.

## Approach

Add **Deepgram's pre-recorded API** (`nova-2`) as a third backend. Its file limit is ~2 GB, so the 25 MB cliff disappears. Routing keeps current behavior unchanged for existing users:

- **Audio ≤ 24 MB:** exactly as before — Groq preferred, OpenAI fallback. Deepgram additionally catches the case where Whisper errors out.
- **Audio > 24 MB:** routed straight to Deepgram instead of failing with 413. Without a Deepgram key, Whisper is still attempted so the user sees the clear 413 error.
- **Standalone:** if `DEEPGRAM_API_KEY` is the only configured key, Deepgram serves as the primary backend.
- **Override:** `--whisper deepgram` forces it.

### Design notes

- **Pure stdlib**, matching `whisper.py` — `urllib` only, no SDK dependency. Same `{start, end, text}` segment shape (from Deepgram `utterances`, with paragraph/transcript fallbacks), same `SystemExit` error contract, same key resolution (env → `~/.config/watch/.env` → `./.env`).
- `detect_language=true` keeps it language-agnostic like the Whisper path.
- The module is named `deepgram_backend` (not `deepgram`) so it can never shadow or be shadowed by the real Deepgram SDK.
- `setup.py` accepts `DEEPGRAM_API_KEY` as a valid transcription key, scaffolds a commented placeholder, and includes it in the install hints. `--check`/`--json` semantics are unchanged otherwise.
- Considered chunked uploads to stay within Whisper's 25 MB instead, but that needs segment-boundary handling, per-chunk timestamp offsetting, and N sequential uploads — a second provider that follows the existing backend contract is simpler and also gives users a provider choice. Happy to adjust if you'd prefer the chunking route.

## Verification

- **59-min YouTube video** (caption pull 429'd, audio 27 MB): routed to Deepgram, returned **628 timestamped segments**, full report, exit 0. Previously: frames-only.
- **Small file regression:** 40 s local clip without flags → still transcribed via **Groq** (unchanged default).
- **Forced:** `--whisper deepgram` with a Groq key present → Deepgram used.
- **Standalone:** only `DEEPGRAM_API_KEY` configured → Deepgram auto-selected as primary; `setup.py --json` reports `ready`.
- **No keys at all:** updated guidance message lists all three options; `--check` exits 3 as before.

Docs (README + SKILL.md) updated accordingly.