### PR TITLE
feat(watch): local Whisper backend (whisper.cpp / mlx), no API key needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to `/watch` are documented here.
 
+## [Unreleased]
+
+### Added
+- **Local Whisper backend — no API key, no network, no upload limit.** Auto-detects two engines: `whisper.cpp` (`whisper-cli` binary + a `ggml-*.bin` model, Metal-accelerated on Apple Silicon) and the `mlx_whisper` / `whisper` Python CLIs. `--whisper local` forces it. whisper.cpp gets 16 kHz WAV; the Python CLIs take the existing mp3.
+- `--accurate` flag (use `large-v3`) and `--model turbo|large-v3|<path>` for picking the local whisper.cpp model by friendly alias — no more typing a full `WHISPER_MODEL=/…/ggml-*.bin` path. `$WHISPER_MODEL` still works for an explicit override.
+- Model auto-pick now prefers full `large-v3-turbo` over the quantized variant when both are present.
+- `WATCH_DISABLE_LOCAL_WHISPER=1` skips local-engine detection entirely (forces cloud backends; also keeps the setup tests hermetic on machines with whisper installed).
+
+### Changed
+- Whisper backend priority is now **local → Groq → OpenAI** (was Groq → OpenAI). The first available backend wins; key-only setups are unaffected. `--whisper` now accepts `local`.
+- `setup.py --check` treats a usable local engine as a valid backend, so no API key is required when local Whisper is installed.
+- `extract_audio` emits 16 kHz PCM WAV when the output path ends in `.wav` (whisper.cpp's native input), else the existing mp3.
+
+> Note: `brew install whisper-cpp` provides the binary but **not** a model — download a `ggml-*.bin` separately (quantized `large-v3-turbo-q5_0` is ~547 MB).
+
 ## [0.2.0] — 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ With Claude Video `/watch` you can paste a URL or a local path, ask a question, 
 1. **You paste a video and a question.** URL (anything yt-dlp supports — YouTube, Loom, TikTok, X, Instagram, plus a few hundred more) or a local path (`.mp4`, `.mov`, `.mkv`, `.webm`).
 2. **`yt-dlp` checks captions first.** At `transcript` detail, captioned URLs return without downloading video. Otherwise, or when Whisper needs audio, it downloads only what the run needs.
 3. **`ffmpeg` extracts frames at the chosen detail.** `efficient` decodes keyframes only (near-instant); `balanced`/`token-burner` prefer scene-change frames and fall back to the duration-aware uniform sampler when they under-produce. JPEGs are 512px wide by default and clamped to 1998px tall for Claude Read compatibility.
-4. **The transcript comes from one of two places.** First try: `yt-dlp` pulls native captions (manual or auto-generated) from the source. Free, instant, accurate-ish. Fallback: extract a mono 16 kHz 64 kbps mp3 audio clip (~480 kB/min) and ship it to Whisper — Groq's `whisper-large-v3` (preferred — cheaper and faster) or OpenAI's `whisper-1`.
+4. **The transcript comes from captions or Whisper.** First try: `yt-dlp` pulls native captions (manual or auto-generated) from the source. Free, instant, accurate-ish. Fallback: extract a mono 16 kHz audio clip and run Whisper, picking the first available backend in priority order — **local** (`whisper.cpp` / `mlx_whisper`, on-device, free, no upload limit), then **Groq** `whisper-large-v3`, then **OpenAI** `whisper-1` (cloud audio is 64 kbps mp3, ~480 kB/min, auto-chunked over the 25 MB cap).
 5. **Frames + transcript are handed to Claude.** The script prints frame paths with `t=MM:SS` markers and the transcript with timestamps. Claude `Read`s each frame in parallel — JPEGs render directly as images in its context.
 6. **Claude answers grounded in what's actually on screen and in the audio.** Not "based on the description" or "according to the title." It saw the frames. It heard the transcript. It answers the way someone who watched the video would.
 7. **Cleanup.** The script prints a working directory at the end. If you're not asking follow-ups, Claude removes it.
@@ -168,9 +168,12 @@ Captions cover the majority of public videos for free. The Whisper fallback only
 | Capability | What you need | Cost |
 |------------|---------------|------|
 | Download + native captions | `yt-dlp` + `ffmpeg` | Free |
-| Whisper fallback (preferred) | [Groq API key](https://console.groq.com/keys) — `whisper-large-v3` | Cheap, fast |
-| Whisper fallback (alt) | [OpenAI API key](https://platform.openai.com/api-keys) — `whisper-1` | Standard pricing |
+| Whisper fallback (local, preferred) | [`whisper.cpp`](https://github.com/ggerganov/whisper.cpp) (`brew install whisper-cpp`) + a `ggml-*.bin` model, or `pip install mlx-whisper` | Free, on-device, Metal-accelerated, no network |
+| Whisper fallback (cloud) | [Groq API key](https://console.groq.com/keys) — `whisper-large-v3` | Cheap, fast |
+| Whisper fallback (cloud, alt) | [OpenAI API key](https://platform.openai.com/api-keys) — `whisper-1` | Standard pricing |
 | Disable Whisper entirely | `--no-whisper` | Free, frames-only when no captions |
+
+Backend priority when several are available: **local → Groq → OpenAI** (override with `--whisper local\|groq\|openai`). The local backend auto-detects a `ggml-*.bin` model in `/opt/homebrew/share/whisper-cpp/` (or `~/.cache/whisper/`, or `$WHISPER_MODEL`), preferring quantized `large-v3-turbo`. Note: `brew install whisper-cpp` installs the binary but **not** a model — download one separately, e.g. `curl -fL -o /opt/homebrew/share/whisper-cpp/ggml-large-v3-turbo-q5_0.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin` (~547 MB).
 
 ## Usage
 
@@ -195,7 +198,9 @@ Other knobs (passed to `scripts/watch.py`):
 - `--max-frames N` — lower the frame cap for a tighter token budget.
 - `--resolution W` — bump frame width to 1024 px when Claude needs to read on-screen text (slides, terminals, code).
 - `--fps F` — override the auto-fps calculation (still capped at 2 fps).
-- `--whisper groq|openai` — force a specific Whisper backend.
+- `--whisper local|groq|openai` — force a specific Whisper backend (default priority: local → Groq → OpenAI).
+- `--accurate` — use the max-accuracy local model (`large-v3`) instead of the fast default (`large-v3-turbo`).
+- `--model turbo|large-v3|<path>` — pick the local whisper.cpp model by alias or path.
 - `--no-whisper` — disable transcription entirely; frames only.
 - `--no-dedup` — keep near-duplicate frames. By default a frame-delta pass drops frames that are visually near-identical to the one before them (held slides, static screen recordings, paused video), so the frame budget is spent on distinct content; this flag turns that off.
 - `--out-dir DIR` — keep working files somewhere specific (default: auto-generated tmp dir).

--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -70,8 +70,8 @@ On non-zero exit, follow the table:
 | Exit | Meaning | Action |
 |------|---------|--------|
 | `2` | Missing binaries (`ffmpeg` / `ffprobe` / `yt-dlp`) | Run installer |
-| `3` | Genuine first run with no Whisper API key | Run installer to scaffold `.env`, then encourage a key (the user may decline — proceed with `--no-whisper`) |
-| `4` | Both missing | Run installer, then encourage a key |
+| `3` | Genuine first run with no Whisper backend (no local `whisper-cli`+model AND no API key) | Run installer to scaffold `.env`, then offer local install or a key (the user may decline — proceed with `--no-whisper`) |
+| `4` | Both missing | Run installer, then offer local install or a key |
 
 Exit `3` only fires before the user has completed setup. Once `SETUP_COMPLETE=true` is written, a keyless install returns exit 0 and is never nagged again.
 
@@ -83,7 +83,7 @@ python3 "${SKILL_DIR}/scripts/setup.py"
 
 On macOS with Homebrew, it auto-installs `ffmpeg` and `yt-dlp`. On Linux/Windows, it prints the exact install commands for the user to run. It scaffolds `~/.config/watch/.env` with commented placeholders and default watch settings at `0600` perms.
 
-**If an API key is still missing after install:** use `AskUserQuestion` to ask the user whether they have a Groq API key (preferred — cheaper, faster) or an OpenAI key. Then write it into `~/.config/watch/.env` — set the matching `GROQ_API_KEY=...` or `OPENAI_API_KEY=...` line. If they don't want to set up Whisper, proceed with `--no-whisper` and tell them videos without native captions will come back frames-only.
+**If no Whisper backend is configured after install:** use `AskUserQuestion` to offer three paths — (1) **local** `whisper.cpp` (`brew install whisper-cpp`, then download a model, e.g. `curl -fL -o /opt/homebrew/share/whisper-cpp/ggml-large-v3-turbo-q5_0.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin` — free, Metal-accelerated, no network at run time, no key); (2) a **Groq** API key (cheap, fast); or (3) an **OpenAI** key. For options 2/3, write into `~/.config/watch/.env` — set the matching `GROQ_API_KEY=...` or `OPENAI_API_KEY=...` line. If they don't want Whisper at all, proceed with `--no-whisper` and tell them videos without native captions come back frames-only. **Note:** `brew install whisper-cpp` installs the binary but **not** a model — you must download a `ggml-*.bin` separately (the quantized turbo model above is ~547 MB).
 
 **First-run watch preference:** after the installer has scaffolded `~/.config/watch/.env`, use `AskUserQuestion` to ask one question:
 
@@ -147,7 +147,9 @@ Optional flags:
 - `--resolution W` — change frame width in px (default 512; bump to 1024 only if the user needs to read on-screen text)
 - `--fps F` — override auto-fps (clamped to 2 fps max)
 - `--out-dir DIR` — keep working files somewhere specific (default: an auto-generated tmp dir)
-- `--whisper groq|openai` — force a specific Whisper backend (default: prefer Groq if both keys exist)
+- `--whisper local|groq|openai` — force a specific Whisper backend (default priority: local whisper.cpp/mlx → Groq → OpenAI, first available wins)
+- `--accurate` — use the max-accuracy local model (`large-v3`) instead of the fast default (`large-v3-turbo`). Slower; use when transcription quality matters more than speed.
+- `--model turbo|large-v3|medium|…|<path>` — pick the local whisper.cpp model by alias or path (overrides the auto-pick and `--accurate`). Cloud backends ignore it.
 - `--no-whisper` — disable the Whisper fallback entirely (frames-only if no captions)
 - `--no-dedup` — keep near-duplicate frames. By default a frame-delta pass drops frames that are visually near-identical to the previous kept one (held slides, static screen recordings, paused video) so the frame budget goes to distinct content; the report's **Frames** line notes how many were dropped. Pass this only if the user needs every sampled frame (e.g. judging subtle frame-to-frame motion).
 
@@ -223,11 +225,12 @@ Behavior:
 The script gets a timestamped transcript in one of two ways:
 
 1. **Native captions (free, preferred).** yt-dlp pulls manual or auto-generated subtitles from the source platform if available.
-2. **Whisper API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever Whisper API has a key configured:
-   - **Groq** — `whisper-large-v3`. Preferred default: cheaper, faster. Get a key at console.groq.com/keys.
-   - **OpenAI** — `whisper-1`. Fallback. Get a key at platform.openai.com/api-keys.
+2. **Whisper fallback.** If no captions came back (or the source is a local file), the script extracts audio and runs the first available backend in priority order:
+   - **Local — `whisper.cpp` (`whisper-cli`) or `mlx_whisper`.** Free, runs on-device, no network, no key, no upload-size limit. Metal-accelerated on Apple Silicon. Auto-detected when a `whisper-cli` binary + a `ggml-*.bin` model (in `/opt/homebrew/share/whisper-cpp/` or `~/.cache/whisper/`, or `$WHISPER_MODEL`) are present, or when `mlx_whisper` is on PATH. **This is the default on the mac mini** (large-v3-turbo-q5_0 installed). whisper.cpp gets 16 kHz WAV; the Python CLIs accept the mp3.
+   - **Groq** — `whisper-large-v3`. Cloud fallback: cheap, fast. Key at console.groq.com/keys.
+   - **OpenAI** — `whisper-1`. Cloud fallback. Key at platform.openai.com/api-keys.
 
-Both keys live in `~/.config/watch/.env`. The script prefers Groq when both are set; override with `--whisper openai` to force OpenAI. Use `--no-whisper` to skip the fallback entirely.
+API keys live in `~/.config/watch/.env`. The script picks the first available backend in the order above; override with `--whisper local|groq|openai`. Use `--no-whisper` to skip the fallback entirely. (Cloud uploads are mono 16 kHz mp3, `ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min — under the 25 MB API cap; the local path has no size limit.)
 
 ## Failure modes and handling
 
@@ -235,7 +238,7 @@ Both keys live in `~/.config/watch/.env`. The script prefers Groq when both are 
 - **No transcript available** → captions missing AND (no Whisper key OR Whisper API failed). Script prints a hint pointing to setup. Proceed frames-only and tell the user.
 - **Long video warning printed** → acknowledge it in your answer. Offer to re-run focused on a specific section via `--start`/`--end` rather than a sparse full-video scan.
 - **Download fails** → yt-dlp's error goes to stderr. If it's a login-required or region-locked video, tell the user plainly; do not keep retrying.
-- **Whisper request fails** → the error is printed to stderr (likely: invalid key or rate limit). Audio over the API's 25 MB upload cap is split into chunks and transcribed automatically, so length alone won't fail it; if some chunks fail the transcript is partial and the dropped chunks are noted on stderr. The report will say "none available" only if every chunk fails. You can retry with `--whisper openai` if Groq failed (or vice versa).
+- **Whisper request fails** → the error is printed to stderr (cloud: invalid key or rate limit; local: missing model file or a `whisper-cli` crash). Cloud audio over the API's 25 MB upload cap is split into chunks and transcribed automatically, so length alone won't fail it; if some chunks fail the transcript is partial and the dropped chunks are noted on stderr. The report will say "none available" only if every chunk fails. You can retry with a different backend via `--whisper local|groq|openai`.
 
 ## Token efficiency
 
@@ -251,8 +254,9 @@ If you already watched a video this session and the user asks a follow-up, do **
 **What this skill does:**
 - Runs `yt-dlp` locally to download the video and pull native captions when the source supports them (public data; the request goes directly to whatever host the URL points at)
 - Runs `ffmpeg` / `ffprobe` locally to extract frames as JPEGs and, when Whisper is needed, a mono 16 kHz audio clip
-- Sends the extracted audio clip to Groq's Whisper API (`api.groq.com/openai/v1/audio/transcriptions`) when `GROQ_API_KEY` is set (preferred — cheaper, faster)
-- Sends the extracted audio clip to OpenAI's audio transcription API (`api.openai.com/v1/audio/transcriptions`) when `OPENAI_API_KEY` is set and Groq is not, or when `--whisper openai` is forced
+- Runs a local Whisper engine (`whisper-cli`/whisper.cpp or `mlx_whisper`) on the extracted audio when one is available — preferred, on-device, nothing leaves the machine
+- Sends the extracted audio clip to Groq's Whisper API (`api.groq.com/openai/v1/audio/transcriptions`) when no local engine is available and `GROQ_API_KEY` is set (or `--whisper groq` is forced)
+- Sends the extracted audio clip to OpenAI's audio transcription API (`api.openai.com/v1/audio/transcriptions`) when neither local nor Groq is available and `OPENAI_API_KEY` is set (or `--whisper openai` is forced)
 - Writes the downloaded video, frames, audio, and an intermediate transcript to a working directory under the system temp dir (or `--out-dir` if specified) so Claude can `Read` them
 - Reads / creates `~/.config/watch/.env` (mode `0600`) to store the Whisper API key(s) and a `SETUP_COMPLETE` marker. As a fallback, also reads `.env` in the current working directory
 
@@ -263,6 +267,6 @@ If you already watched a video this session and the user asks a follow-up, do **
 - Does not log, cache, or write API keys to stdout, stderr, or output files
 - Does not persist anything outside the working directory and `~/.config/watch/.env` — clean up the working directory when you're done (Step 5)
 
-**Bundled scripts:** `scripts/watch.py` (entry point), `scripts/download.py` (yt-dlp wrapper), `scripts/frames.py` (ffmpeg frame extraction), `scripts/transcribe.py` (caption selection + Whisper orchestration), `scripts/whisper.py` (Groq / OpenAI clients), `scripts/setup.py` (preflight + installer)
+**Bundled scripts:** `scripts/watch.py` (entry point), `scripts/download.py` (yt-dlp wrapper), `scripts/frames.py` (ffmpeg frame extraction), `scripts/transcribe.py` (caption selection + Whisper orchestration), `scripts/whisper.py` (local whisper.cpp/mlx + Groq / OpenAI clients), `scripts/setup.py` (preflight + installer)
 
 Review scripts before first use to verify behavior.

--- a/skills/watch/scripts/setup.py
+++ b/skills/watch/scripts/setup.py
@@ -113,7 +113,40 @@ def _read_env_key(name: str) -> str | None:
     return None
 
 
+# Local whisper.cpp ggml models, checked before requiring any cloud API key.
+LOCAL_MODEL_DIRS = (
+    "/opt/homebrew/share/whisper-cpp",
+    "/usr/local/share/whisper-cpp",
+    str(Path.home() / ".cache" / "whisper"),
+)
+LOCAL_MODEL_NAMES = (
+    "ggml-large-v3-turbo-q5_0.bin",
+    "ggml-large-v3-turbo.bin",
+    "ggml-large-v3-q5_0.bin",
+    "ggml-large-v3.bin",
+    "ggml-medium.bin",
+    "ggml-small.bin",
+    "ggml-base.bin",
+)
+
+
+def _have_local_whisper() -> bool:
+    """True if a local engine is usable: whisper.cpp (binary + model) or mlx/openai-whisper."""
+    if os.environ.get("WATCH_DISABLE_LOCAL_WHISPER"):
+        return False
+    override = os.environ.get("WHISPER_MODEL")
+    has_cpp_bin = any(_which(b) for b in ("whisper-cli", "whisper-cpp", "main"))
+    has_model = (override and Path(override).expanduser().exists()) or any(
+        (Path(d) / n).exists() for d in LOCAL_MODEL_DIRS for n in LOCAL_MODEL_NAMES
+    )
+    if has_cpp_bin and has_model:
+        return True
+    return bool(_which("mlx_whisper") or _which("whisper"))
+
+
 def _have_api_key() -> tuple[bool, str | None]:
+    if _have_local_whisper():
+        return True, "local"
     if _read_env_key("GROQ_API_KEY"):
         return True, "groq"
     if _read_env_key("OPENAI_API_KEY"):

--- a/skills/watch/scripts/watch.py
+++ b/skills/watch/scripts/watch.py
@@ -7,6 +7,7 @@ then Reads each frame path to see the video.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -19,7 +20,7 @@ from config import frame_cap, get_config  # noqa: E402
 from download import download, fetch_captions, is_url  # noqa: E402
 from frames import MAX_FPS, auto_fps, auto_fps_focus, extract_at_timestamps, extract_keyframes, extract_scene_or_uniform, format_time, get_metadata, merge_frames, parse_time, parse_timestamps  # noqa: E402
 from transcribe import filter_range, format_transcript, parse_vtt  # noqa: E402
-from whisper import load_api_key, transcribe_video  # noqa: E402
+from whisper import load_api_key, resolve_model_alias, transcribe_video  # noqa: E402
 
 
 def main() -> int:
@@ -56,9 +57,20 @@ def main() -> int:
     )
     ap.add_argument(
         "--whisper",
-        choices=["groq", "openai"],
+        choices=["local", "groq", "openai"],
         default=None,
-        help="Force a specific Whisper backend. Default: prefer Groq, fall back to OpenAI.",
+        help="Force a specific Whisper backend. Default priority: local (whisper.cpp/mlx) → Groq → OpenAI.",
+    )
+    ap.add_argument(
+        "--accurate",
+        action="store_true",
+        help="Use the max-accuracy local model (large-v3) instead of the fast default (turbo). Slower.",
+    )
+    ap.add_argument(
+        "--model",
+        default=None,
+        help="Local whisper.cpp model: an alias (turbo, large-v3, medium, small, base) or a path to a ggml .bin. "
+             "Overrides the auto-pick (and --accurate). Cloud backends ignore this.",
     )
     ap.add_argument(
         "--no-dedup",
@@ -67,6 +79,12 @@ def main() -> int:
              "frames (static screen recordings, held slides) instead of collapsing them.",
     )
     args = ap.parse_args()
+
+    # Translate the friendly --model / --accurate into WHISPER_MODEL, which the
+    # local whisper.cpp backend honors. (Cloud backends have fixed models.)
+    chosen_model = args.model or ("large-v3" if args.accurate else None)
+    if chosen_model:
+        os.environ["WHISPER_MODEL"] = resolve_model_alias(chosen_model)
 
     config = get_config()
     detail = args.detail or str(config["detail"])
@@ -253,9 +271,9 @@ def main() -> int:
                 print(f"[watch] whisper fallback failed: {exc}", file=sys.stderr)
         else:
             hint = (
-                f"--whisper {args.whisper} was set but the matching API key is missing"
+                f"--whisper {args.whisper} was set but that backend isn't available"
                 if args.whisper else
-                "no subtitles and no Whisper API key found"
+                "no subtitles and no Whisper backend found (no local whisper.cpp/mlx, no API key)"
             )
             setup_py = SCRIPT_DIR / "setup.py"
             print(

--- a/skills/watch/scripts/whisper.py
+++ b/skills/watch/scripts/whisper.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-"""Transcribe a video via Groq or OpenAI Whisper API.
+"""Transcribe a video locally (whisper.cpp / mlx) or via Groq / OpenAI Whisper API.
 
-Strategy: extract audio (mono 16kHz mp3, tiny payload), upload to whichever
-API has a key. Returns segments in the same shape as transcribe.parse_vtt so
-the rest of the pipeline (filter_range, format_transcript) doesn't care where
-the transcript came from.
+Strategy: extract audio (mono 16kHz), then run it through the first available
+backend in priority order — local → Groq → OpenAI. Returns segments in the same
+shape as transcribe.parse_vtt so the rest of the pipeline (filter_range,
+format_transcript) doesn't care where the transcript came from.
 
-Pure stdlib — no `pip install groq` or `pip install openai` needed.
+Pure stdlib — local backends are external binaries (like ffmpeg/yt-dlp), and the
+cloud clients are hand-rolled multipart, so there's no `pip install` requirement.
 """
 from __future__ import annotations
 
@@ -62,11 +63,125 @@ def plan_chunks(
     return plan
 
 
-def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, None]:
-    """Return (backend, api_key). Prefers Groq, falls back to OpenAI.
+# --- Local backends (auto-detected, no network, no API key) -------------------
+# Two local engines are supported, in priority order:
+#   1. whisper.cpp — needs a `whisper-cli` (or `whisper-cpp`/`main`) binary AND a
+#      ggml-*.bin model on disk. Metal-accelerated on Apple Silicon.
+#   2. mlx_whisper / openai-whisper — Python CLIs that download their own model.
+# Set WHISPER_MODEL to point whisper.cpp at a specific ggml model file.
+WHISPER_CPP_BINS = ("whisper-cli", "whisper-cpp", "main")
+LOCAL_MODEL_DIRS = (
+    "/opt/homebrew/share/whisper-cpp",
+    "/usr/local/share/whisper-cpp",
+    str(Path.home() / ".cache" / "whisper"),
+)
+# Preferred ggml models, best-first. Full large-v3-turbo is the default: fast and
+# high-quality. Quantized variants are disk-frugal fallbacks; full large-v3 is the
+# max-accuracy option (reach it with --accurate / --model large-v3, or WHISPER_MODEL).
+LOCAL_MODEL_NAMES = (
+    "ggml-large-v3-turbo.bin",
+    "ggml-large-v3-turbo-q5_0.bin",
+    "ggml-large-v3.bin",
+    "ggml-large-v3-q5_0.bin",
+    "ggml-medium.bin",
+    "ggml-small.bin",
+    "ggml-base.bin",
+)
 
-    If `preferred` is "groq" or "openai", only that backend's key is considered.
+# Friendly names for --model / --accurate, mapped to ggml filenames.
+MODEL_ALIASES = {
+    "turbo": "ggml-large-v3-turbo.bin",
+    "large-v3-turbo": "ggml-large-v3-turbo.bin",
+    "accurate": "ggml-large-v3.bin",
+    "large-v3": "ggml-large-v3.bin",
+    "medium": "ggml-medium.bin",
+    "small": "ggml-small.bin",
+    "base": "ggml-base.bin",
+}
+
+
+def _find_ggml_model() -> str | None:
+    """Locate a whisper.cpp ggml model: WHISPER_MODEL override, then known dirs."""
+    override = os.environ.get("WHISPER_MODEL")
+    if override and Path(override).expanduser().exists():
+        return str(Path(override).expanduser())
+    for directory in LOCAL_MODEL_DIRS:
+        for name in LOCAL_MODEL_NAMES:
+            candidate = Path(directory) / name
+            if candidate.exists():
+                return str(candidate)
+    return None
+
+
+def resolve_model_alias(name: str) -> str:
+    """Map a friendly model name to a whisper.cpp ggml model path.
+
+    Accepts an alias (turbo, large-v3/accurate, medium, small, base), a bare
+    ggml filename, or a path to a `.bin`. Returns the resolved path; raises
+    SystemExit if the model file isn't found in the known dirs.
     """
+    p = Path(name).expanduser()
+    if p.suffix == ".bin" and p.exists():
+        return str(p)
+    fname = MODEL_ALIASES.get(name.lower()) or (name if name.endswith(".bin") else f"ggml-{name}.bin")
+    for directory in LOCAL_MODEL_DIRS:
+        candidate = Path(directory) / fname
+        if candidate.exists():
+            return str(candidate)
+    raise SystemExit(
+        f"whisper model '{name}' not found (looked for {fname} in: "
+        + ", ".join(LOCAL_MODEL_DIRS) + "). Download it there first."
+    )
+
+
+def detect_local_engine(model_override: str | None = None) -> dict | None:
+    """Return {engine, bin, model} for an available local backend, else None.
+
+    Priority: whisper.cpp (binary + ggml model) → mlx_whisper → openai-whisper.
+    The Python CLIs are detected by name on PATH; they fetch their own models.
+    Set WATCH_DISABLE_LOCAL_WHISPER to skip detection (forces cloud backends).
+    """
+    if os.environ.get("WATCH_DISABLE_LOCAL_WHISPER"):
+        return None
+    cpp_bin = next((shutil.which(b) for b in WHISPER_CPP_BINS if shutil.which(b)), None)
+    model = model_override or _find_ggml_model()
+    if cpp_bin and model:
+        return {"engine": "whisper.cpp", "bin": cpp_bin, "model": model}
+
+    if shutil.which("mlx_whisper"):
+        return {
+            "engine": "mlx",
+            "bin": shutil.which("mlx_whisper"),
+            "model": model_override or "mlx-community/whisper-large-v3-turbo",
+        }
+    if shutil.which("whisper"):  # openai-whisper CLI
+        return {
+            "engine": "openai-whisper",
+            "bin": shutil.which("whisper"),
+            "model": model_override or "large-v3-turbo",
+        }
+    return None
+
+
+def _have_local_whisper() -> bool:
+    return detect_local_engine() is not None
+
+
+def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, None]:
+    """Resolve a transcription backend. Priority: local → Groq → OpenAI.
+
+    Returns (backend, credential). For "local" the credential is the engine label
+    (model path or model id — a sentinel; transcribe_video re-detects the engine).
+    For "groq"/"openai" it's the API key. If `preferred` names a backend, only
+    that one is considered. Returns (None, None) if nothing is available.
+    """
+    if preferred == "local" or (preferred is None and _have_local_whisper()):
+        engine = detect_local_engine()
+        if engine:
+            return "local", (engine.get("model") or engine["engine"])
+        if preferred == "local":
+            return None, None
+
     def _from_env(name: str) -> str | None:
         value = os.environ.get(name)
         return value.strip() if value else None
@@ -113,11 +228,17 @@ def load_api_key(preferred: str | None = None) -> tuple[str, str] | tuple[None, 
 
 
 def extract_audio(video_path: str, out_path: Path) -> Path:
-    """Extract mono 16kHz 64kbps mp3 — ~480 kB/min, fits any Whisper limit."""
+    """Extract mono 16kHz audio. `.wav` → PCM s16le (whisper.cpp's native input);
+    anything else → 64kbps mp3 (~480 kB/min, fits any cloud Whisper upload limit).
+    """
     if shutil.which("ffmpeg") is None:
         raise SystemExit("ffmpeg is not installed. Install with: brew install ffmpeg")
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
+    if out_path.suffix.lower() == ".wav":
+        codec = ["-acodec", "pcm_s16le"]
+    else:
+        codec = ["-acodec", "libmp3lame", "-b:a", "64k"]
     cmd = [
         "ffmpeg",
         "-hide_banner",
@@ -125,10 +246,9 @@ def extract_audio(video_path: str, out_path: Path) -> Path:
         "-y",
         "-i", str(Path(video_path).resolve()),
         "-vn",
-        "-acodec", "libmp3lame",
+        *codec,
         "-ar", "16000",
         "-ac", "1",
-        "-b:a", "64k",
         str(out_path.resolve()),
     ]
     result = subprocess.run(cmd, capture_output=True, text=True)
@@ -429,34 +549,49 @@ def transcribe_video(
     if not backend or not api_key:
         setup_py = Path(__file__).resolve().parent / "setup.py"
         raise SystemExit(
-            "No Whisper API key available. Set GROQ_API_KEY (preferred) or OPENAI_API_KEY "
-            "in the environment or in ~/.config/watch/.env. "
+            "No Whisper backend available. Install whisper.cpp locally "
+            "(`brew install whisper-cpp` + a ggml model), or set GROQ_API_KEY / "
+            "OPENAI_API_KEY in the environment or in ~/.config/watch/.env. "
             f"Run `python3 {setup_py}` to configure."
         )
 
-    print(f"[watch] extracting audio for Whisper ({backend})…", file=sys.stderr)
-    audio_path = extract_audio(video_path, audio_out)
-    audio_bytes = audio_path.stat().st_size
-
-    def transcribe_one(path: Path) -> list[dict]:
-        return _transcribe_file(backend, api_key, path)
-
-    if audio_bytes <= MAX_UPLOAD_BYTES:
-        print(
-            f"[watch] audio: {audio_bytes / 1024:.0f} kB — uploading to {backend} Whisper…",
-            file=sys.stderr,
-        )
-        segments = transcribe_one(audio_path)
+    if backend == "local":
+        engine = detect_local_engine()
+        if not engine:
+            raise SystemExit(
+                "local Whisper requested but no engine found — install `whisper-cpp` "
+                "+ a ggml model, or `pip install mlx-whisper`."
+            )
+        # whisper.cpp wants 16kHz WAV; the Python CLIs accept anything via ffmpeg.
+        # No upload cap locally, so the chunking path below doesn't apply.
+        wav_out = audio_out.with_suffix(".wav") if engine["engine"] == "whisper.cpp" else audio_out
+        print(f"[watch] extracting audio for local Whisper ({engine['engine']})…", file=sys.stderr)
+        audio_path = extract_audio(video_path, wav_out)
+        segments = _transcribe_local(audio_path, engine)
     else:
-        duration = audio_duration(audio_path)
-        plan = plan_chunks(duration, audio_bytes, MAX_UPLOAD_BYTES)
-        print(
-            f"[watch] audio: {audio_bytes / (1024 * 1024):.0f} MB exceeds "
-            f"{MAX_UPLOAD_BYTES // (1024 * 1024)} MB — splitting into {len(plan)} chunks…",
-            file=sys.stderr,
-        )
-        chunks = split_audio(audio_path, audio_out.parent / "chunks", plan)
-        segments = transcribe_chunks(chunks, transcribe_one)
+        print(f"[watch] extracting audio for Whisper ({backend})…", file=sys.stderr)
+        audio_path = extract_audio(video_path, audio_out)
+        audio_bytes = audio_path.stat().st_size
+
+        def transcribe_one(path: Path) -> list[dict]:
+            return _transcribe_file(backend, api_key, path)
+
+        if audio_bytes <= MAX_UPLOAD_BYTES:
+            print(
+                f"[watch] audio: {audio_bytes / 1024:.0f} kB — uploading to {backend} Whisper…",
+                file=sys.stderr,
+            )
+            segments = transcribe_one(audio_path)
+        else:
+            duration = audio_duration(audio_path)
+            plan = plan_chunks(duration, audio_bytes, MAX_UPLOAD_BYTES)
+            print(
+                f"[watch] audio: {audio_bytes / (1024 * 1024):.0f} MB exceeds "
+                f"{MAX_UPLOAD_BYTES // (1024 * 1024)} MB — splitting into {len(plan)} chunks…",
+                file=sys.stderr,
+            )
+            chunks = split_audio(audio_path, audio_out.parent / "chunks", plan)
+            segments = transcribe_chunks(chunks, transcribe_one)
 
     if not segments:
         raise SystemExit("Whisper returned no transcript segments")
@@ -465,9 +600,77 @@ def transcribe_video(
     return segments, backend
 
 
+def _transcribe_local(audio_path: Path, engine: dict) -> list[dict]:
+    """Dispatch to the detected local engine. Returns {start, end, text} segments."""
+    if engine["engine"] == "whisper.cpp":
+        return _transcribe_whisper_cpp(audio_path, engine["bin"], engine["model"])
+    return _transcribe_whisper_cli(audio_path, engine["bin"], engine["model"], engine["engine"])
+
+
+def _transcribe_whisper_cpp(audio_path: Path, binary: str, model_path: str) -> list[dict]:
+    """Run whisper.cpp (`whisper-cli`). Metal-accelerated on Apple Silicon."""
+    out_base = audio_path.with_suffix("")
+    cmd = [
+        binary,
+        "-m", model_path,
+        "-oj",                       # write JSON
+        "-of", str(out_base),        # output prefix (-> <out_base>.json)
+        "-l", "auto",                # auto-detect language
+        str(audio_path),
+    ]
+    print(f"[watch] running local whisper.cpp ({Path(model_path).name})…", file=sys.stderr)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise SystemExit(f"whisper-cli failed: {result.stderr.strip()[-400:]}")
+
+    json_path = Path(f"{out_base}.json")
+    if not json_path.exists():
+        raise SystemExit(f"whisper-cli produced no JSON at {json_path}")
+
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    out: list[dict] = []
+    for seg in data.get("transcription") or []:
+        text = (seg.get("text") or "").strip()
+        if not text:
+            continue
+        offsets = seg.get("offsets") or {}
+        out.append({
+            "start": round((offsets.get("from") or 0) / 1000.0, 2),  # ms → s
+            "end": round((offsets.get("to") or 0) / 1000.0, 2),
+            "text": text,
+        })
+    return out
+
+
+def _transcribe_whisper_cli(audio_path: Path, binary: str, model: str, engine: str) -> list[dict]:
+    """Run an openai-whisper-shaped CLI (`mlx_whisper` or `whisper`) → JSON segments.
+
+    Both write `<audio-stem>.json` (verbose schema: {segments:[{start,end,text}]}).
+    Flag spelling differs: openai-whisper uses underscores, mlx_whisper hyphens.
+    """
+    out_dir = audio_path.parent
+    if engine == "mlx":
+        flags = ["--model", model, "--output-dir", str(out_dir), "--output-format", "json"]
+    else:  # openai-whisper
+        flags = ["--model", model, "--output_dir", str(out_dir), "--output_format", "json", "--task", "transcribe"]
+    cmd = [binary, str(audio_path), *flags]
+    print(f"[watch] running local {engine} ({model})…", file=sys.stderr)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise SystemExit(f"{engine} failed: {result.stderr.strip()[-400:]}")
+
+    json_path = audio_path.with_suffix(".json")
+    if not json_path.exists():
+        matches = sorted(out_dir.glob(f"{audio_path.stem}*.json"))
+        if not matches:
+            raise SystemExit(f"{engine} produced no JSON in {out_dir}")
+        json_path = matches[0]
+    return _segments_from_response(json.loads(json_path.read_text(encoding="utf-8")))
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("usage: whisper.py <video-path> [<audio-out.mp3>] [--backend groq|openai]", file=sys.stderr)
+        print("usage: whisper.py <video-path> [<audio-out.mp3>] [--backend local|groq|openai]", file=sys.stderr)
         raise SystemExit(2)
 
     video = sys.argv[1]

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -17,6 +17,9 @@ def _run(args, *, home=None, extra_env=None):
     env.pop("GROQ_API_KEY", None)
     env.pop("OPENAI_API_KEY", None)
     env.pop("SETUP_COMPLETE", None)
+    # Likewise a real local whisper install (whisper-cli / mlx_whisper) on the
+    # developer's machine — these tests assert the cloud-key paths.
+    env["WATCH_DISABLE_LOCAL_WHISPER"] = "1"
     if home is not None:
         env["HOME"] = str(home)
         env["USERPROFILE"] = str(home)  # Windows


### PR DESCRIPTION
## What & why

Today `/watch` requires a Groq or OpenAI key the moment a video lacks captions (local files, most TikToks, some Vimeos). This adds an **on-device** transcription path: free, private, no network, no 25 MB upload cap, and faster than a cloud round-trip on Apple Silicon.

Backend priority becomes **local → Groq → OpenAI**, first-available-wins, so existing key-only setups behave exactly as before.

There are three open local-Whisper PRs ([#5](https://github.com/bradautomates/claude-video/pull/5), [#18](https://github.com/bradautomates/claude-video/pull/18), [#32](https://github.com/bradautomates/claude-video/pull/32)); this one auto-detects **both** engine families rather than picking one, and corrects a factual issue in #32 (Homebrew's `whisper-cpp` no longer ships a model — see note below).

## Changes

- **whisper.cpp** (`whisper-cli` / `whisper-cpp` / `main` binary + a `ggml-*.bin` model). Metal-accelerated on Apple Silicon. Auto-detected from `/opt/homebrew/share/whisper-cpp/`, `~/.cache/whisper/`, or `$WHISPER_MODEL`, preferring quantized `large-v3-turbo`.
- **mlx_whisper / openai-whisper** Python CLIs — detected on PATH; they fetch their own model. Flag-spelling differences (hyphen vs underscore) are handled.
- `extract_audio` emits **16 kHz PCM WAV** for `.wav` targets (whisper.cpp's native input); the cloud path still uses mp3.
- `setup.py --check` treats a usable local engine as a valid backend, so no API key is demanded when local Whisper is installed.
- `--whisper` now accepts `local`. Pure stdlib preserved — local engines are external binaries, like `ffmpeg`/`yt-dlp`.
- Docs updated (SKILL.md, README.md, CHANGELOG.md).

> **Note for macOS users:** `brew install whisper-cpp` installs the binary but **not** a model. Download one separately, e.g.
> `curl -fL -o /opt/homebrew/share/whisper-cpp/ggml-large-v3-turbo-q5_0.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin` (~547 MB).

## Testing

On Apple M4 (24 GB), whisper-cpp + `ggml-large-v3-turbo-q5_0`:
- `whisper.py <video> --backend local` → extracts WAV, runs `whisper-cli`, returns `{start,end,text}` segments with correct timestamps.
- `watch.py <local-file>` with **no API key set** → auto-selects local, transcript reported `via whisper (local)`.
- `setup.py --check` → exit 0; `--json` → `status=ready, whisper_backend=local`.
- `python3 -m py_compile` passes on all scripts.

## Model Used

- [x] I verified the changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)