### PR TITLE
fix(download): add YouTube anti-bot flags so media URLs stop 403ing

### DIFF
--- a/skills/watch/scripts/download.py
+++ b/skills/watch/scripts/download.py
@@ -127,6 +127,12 @@ def download_url(
     cmd = [
         "yt-dlp",
         "-N", "8",
+        # YouTube anti-bot: solve the JS "n" throttling challenge (needs deno, fetched
+        # from GitHub + cached) and impersonate a browser (needs curl_cffi). Without these,
+        # media URLs intermittently 403 and no frames get extracted. Both degrade gracefully
+        # if unavailable (yt-dlp warns and falls back to the un-solved path).
+        "--remote-components", "ejs:github",
+        "--impersonate", "chrome",
         "-f", fmt,
         "--merge-output-format", "mp4",
         "--write-info-json",


### PR DESCRIPTION
## Problem

On some networks/videos, `yt-dlp` intermittently returns **403 on YouTube media URLs**, so the video download fails and `/watch` extracts **no frames** — while captions/info-json still succeed, which makes it easy to miss that anything broke. Root cause: the JS **"n" throttling challenge** is left unsolved (the solver is skipped by default) and no browser impersonation target is set.

## Fix

Add two flags to the media download command in `skills/watch/scripts/download.py`:

- `--remote-components ejs:github` — fetches the deno-based JS "n" challenge solver
- `--impersonate chrome` — browser impersonation via `curl_cffi`

Both **degrade gracefully** when `deno`/`curl_cffi` aren't installed: yt-dlp emits a warning and falls back to the un-solved path. So this is safe for users without the extra dependencies, and fixes reliable frame extraction for users who have them.

## Testing

Verified end-to-end on Windows against a real YouTube video: with the flags, the n-challenge/impersonation warnings are gone and frames extract reliably (previously an intermittent 403 → zero frames). Caption-first path unaffected.