### PR TITLE
feat: add structured YouTube source probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Other knobs (passed to `scripts/watch.py`):
 │   ├── SKILL.md                  # skill contract — the source of truth across all surfaces
 │   └── scripts/
 │       ├── watch.py              # entry point — orchestrates download → frames → transcript
+│       ├── probe.py              # machine-readable YouTube source discovery without media download
 │       ├── download.py           # yt-dlp wrapper
 │       ├── frames.py             # ffmpeg frame extraction + auto-fps logic
 │       ├── transcribe.py         # VTT parsing + dedupe + Whisper orchestration
@@ -228,6 +229,16 @@ Other knobs (passed to `scripts/watch.py`):
 ├── tests/                        # pytest suite (ffmpeg-synthesized clips, no network)
 └── .github/workflows/            # release.yml — auto-builds watch.skill on tag push
 ```
+
+### Machine-readable YouTube source discovery
+
+Capture workflows can inspect a YouTube channel, playlist, or single-video URL without downloading media:
+
+```bash
+python3 skills/watch/scripts/probe.py "https://www.youtube.com/@example/videos"
+```
+
+The command prints a versioned JSON contract with source identity, canonical URL, title, video entries, publication times, caption availability, and (when verified) the channel's official feed URL. Errors are returned as JSON with a stable `error.kind`, so downstream code does not need to parse yt-dlp's human-facing text. A non-object JSON result such as `null` is treated as an extractor-format error rather than a process crash.
 
 ## Develop
 

--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -263,6 +263,16 @@ If you already watched a video this session and the user asks a follow-up, do **
 - Does not log, cache, or write API keys to stdout, stderr, or output files
 - Does not persist anything outside the working directory and `~/.config/watch/.env` — clean up the working directory when you're done (Step 5)
 
-**Bundled scripts:** `scripts/watch.py` (entry point), `scripts/download.py` (yt-dlp wrapper), `scripts/frames.py` (ffmpeg frame extraction), `scripts/transcribe.py` (caption selection + Whisper orchestration), `scripts/whisper.py` (Groq / OpenAI clients), `scripts/setup.py` (preflight + installer)
+**Bundled scripts:** `scripts/watch.py` (entry point), `scripts/probe.py` (machine-readable YouTube source discovery), `scripts/download.py` (yt-dlp wrapper), `scripts/frames.py` (ffmpeg frame extraction), `scripts/transcribe.py` (caption selection + Whisper orchestration), `scripts/whisper.py` (Groq / OpenAI clients), `scripts/setup.py` (preflight + installer)
+
+### Structured YouTube source discovery
+
+Downstream capture workflows that need channel, playlist, or single-video identity can call the bundled probe without invoking `/watch` or downloading media:
+
+```bash
+python3 "${SKILL_DIR}/scripts/probe.py" "<youtube-url>"
+```
+
+The command writes a versioned JSON object to stdout. Successful responses have `status: "ok"`, `sourceType` (`channel`, `playlist`, or `video`), `platformId`, `canonicalUrl`, `title`, `entries`, and optional `officialFeedUrl`. Each entry contains a stable video `id`, URL, title, optional `publishedAt`, and availability. Failed responses have `status: "error"` and an `error.kind` that distinguishes authentication, regional restriction, rate limiting, missing content, extractor changes, and general unavailability. A JSON `null` or other non-object response from `yt-dlp` is reported as a structured `format_changed` error.
 
 Review scripts before first use to verify behavior.

--- a/skills/watch/scripts/probe.py
+++ b/skills/watch/scripts/probe.py
@@ -27,6 +27,8 @@ def probe(source: str) -> dict[str, Any]:
         raw = json.loads(result.stdout)
     except json.JSONDecodeError:
         return failure("format_changed", "yt-dlp returned invalid JSON")
+    if not isinstance(raw, dict):
+        return failure("format_changed", "yt-dlp returned an unexpected JSON value")
     normalized = normalize(raw, source)
     if result.returncode != 0:
         normalized["warnings"].append({"kind": classify_error(result.stderr), "message": clean_message(result.stderr, result.returncode)})
@@ -47,12 +49,16 @@ def normalize(raw: dict[str, Any], source: str) -> dict[str, Any]:
                 unavailable += 1
                 continue
             video_id = str(entry["id"])
+            availability = entry.get("availability")
+            available = availability is None or availability in {"public", "unlisted"}
+            if not available:
+                unavailable += 1
             entries.append({
                 "id": video_id,
                 "url": entry_url(entry, video_id),
                 "title": entry.get("title") or "(unavailable title)",
                 "publishedAt": upload_date(entry),
-                "available": entry.get("availability") not in {"private", "subscriber_only", "premium_only"},
+                "available": available,
             })
     elif platform_id:
         entries.append({
@@ -75,10 +81,19 @@ def normalize(raw: dict[str, Any], source: str) -> dict[str, Any]:
 def identify_type(raw: dict[str, Any], source: str, is_collection: bool) -> str:
     parsed = urlparse(source)
     query = parse_qs(parsed.query)
-    if not is_collection or parsed.hostname == "youtu.be" or parsed.path == "/watch":
-        return "video"
     if "list" in query or "/playlist" in parsed.path:
         return "playlist"
+    if parsed.hostname == "youtu.be" or parsed.path == "/watch" or parsed.path.startswith("/shorts/"):
+        return "video"
+    if any(parsed.path.startswith(prefix) for prefix in ("/@", "/channel/", "/c/", "/user/")):
+        return "channel"
+    if not is_collection:
+        raw_id = str(raw.get("id") or "")
+        if raw_id.startswith("PL"):
+            return "playlist"
+        if raw_id.startswith("UC"):
+            return "channel"
+        return "video"
     return "channel"
 
 
@@ -123,12 +138,12 @@ def entry_url(entry: dict[str, Any], video_id: str) -> str:
 
 def classify_error(stderr: str) -> str:
     text = stderr.lower()
+    if any(term in text for term in ("too many requests", "http error 429", "rate limit")):
+        return "rate_limited"
     if any(term in text for term in ("private video", "sign in", "login", "cookies")):
         return "authentication_required"
     if any(term in text for term in ("not available in your country", "geo-restricted", "region")):
         return "region_restricted"
-    if any(term in text for term in ("too many requests", "http error 429", "rate limit")):
-        return "rate_limited"
     if any(term in text for term in ("video unavailable", "has been removed", "deleted")):
         return "not_found"
     if any(term in text for term in ("unsupported url", "unable to extract", "extractor")):

--- a/skills/watch/scripts/probe.py
+++ b/skills/watch/scripts/probe.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Machine-readable YouTube source discovery using yt-dlp without media download."""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+
+def probe(source: str) -> dict[str, Any]:
+    if shutil.which("yt-dlp") is None:
+        return failure("unavailable", "yt-dlp is not installed")
+    if not is_youtube_url(source):
+        return failure("format_changed", "source is not a YouTube URL")
+    command = [
+        "yt-dlp", "--dump-single-json", "--flat-playlist", "--skip-download",
+        "--ignore-errors", "--no-warnings", "--", source,
+    ]
+    result = subprocess.run(command, capture_output=True, text=True)
+    if not result.stdout.strip():
+        return failure(classify_error(result.stderr), clean_message(result.stderr, result.returncode))
+    try:
+        raw = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return failure("format_changed", "yt-dlp returned invalid JSON")
+    normalized = normalize(raw, source)
+    if result.returncode != 0:
+        normalized["warnings"].append({"kind": classify_error(result.stderr), "message": clean_message(result.stderr, result.returncode)})
+    return normalized
+
+
+def normalize(raw: dict[str, Any], source: str) -> dict[str, Any]:
+    entries_value = raw.get("entries")
+    is_collection = isinstance(entries_value, list)
+    source_type = identify_type(raw, source, is_collection)
+    platform_id = stable_id(raw, source_type)
+    canonical_url = raw.get("webpage_url") or canonical_url_for(source_type, platform_id, source)
+    entries: list[dict[str, Any]] = []
+    unavailable = 0
+    if is_collection:
+        for entry in entries_value:
+            if not isinstance(entry, dict) or not entry.get("id"):
+                unavailable += 1
+                continue
+            video_id = str(entry["id"])
+            entries.append({
+                "id": video_id,
+                "url": entry_url(entry, video_id),
+                "title": entry.get("title") or "(unavailable title)",
+                "publishedAt": upload_date(entry),
+                "available": entry.get("availability") not in {"private", "subscriber_only", "premium_only"},
+            })
+    elif platform_id:
+        entries.append({
+            "id": platform_id, "url": canonical_url, "title": raw.get("title") or "(untitled)",
+            "publishedAt": upload_date(raw), "available": True,
+            "captionsAvailable": bool(raw.get("subtitles") or raw.get("automatic_captions")),
+        })
+    warnings = []
+    if unavailable:
+        warnings.append({"kind": "partial_unavailable", "message": f"{unavailable} entries were unavailable"})
+    channel_id = raw.get("channel_id") or (platform_id if source_type == "channel" and str(platform_id).startswith("UC") else None)
+    return {
+        "schemaVersion": 1, "status": "ok", "sourceType": source_type, "platformId": platform_id,
+        "canonicalUrl": canonical_url, "title": raw.get("title") or raw.get("channel") or raw.get("uploader") or "(untitled)",
+        "officialFeedUrl": f"https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}" if channel_id else None,
+        "entries": entries, "warnings": warnings,
+    }
+
+
+def identify_type(raw: dict[str, Any], source: str, is_collection: bool) -> str:
+    parsed = urlparse(source)
+    query = parse_qs(parsed.query)
+    if not is_collection or parsed.hostname == "youtu.be" or parsed.path == "/watch":
+        return "video"
+    if "list" in query or "/playlist" in parsed.path:
+        return "playlist"
+    return "channel"
+
+
+def stable_id(raw: dict[str, Any], source_type: str) -> str | None:
+    if source_type == "channel":
+        return raw.get("channel_id") or raw.get("uploader_id") or raw.get("id")
+    return raw.get("playlist_id") or raw.get("id")
+
+
+def canonical_url_for(source_type: str, platform_id: str | None, fallback: str) -> str:
+    if not platform_id:
+        return fallback
+    if source_type == "video":
+        return f"https://www.youtube.com/watch?v={platform_id}"
+    if source_type == "playlist":
+        return f"https://www.youtube.com/playlist?list={platform_id}"
+    if str(platform_id).startswith("UC"):
+        return f"https://www.youtube.com/channel/{platform_id}"
+    return fallback
+
+
+def upload_date(value: dict[str, Any]) -> str | None:
+    raw = value.get("upload_date") or value.get("release_date")
+    if isinstance(raw, str) and len(raw) == 8 and raw.isdigit():
+        return f"{raw[:4]}-{raw[4:6]}-{raw[6:]}T00:00:00Z"
+    timestamp = value.get("timestamp") or value.get("release_timestamp")
+    if isinstance(timestamp, (int, float)):
+        from datetime import datetime, timezone
+        return datetime.fromtimestamp(timestamp, timezone.utc).isoformat().replace("+00:00", "Z")
+    return None
+
+
+def entry_url(entry: dict[str, Any], video_id: str) -> str:
+    webpage_url = entry.get("webpage_url")
+    if isinstance(webpage_url, str) and webpage_url.startswith("http"):
+        return webpage_url
+    url = entry.get("url")
+    if isinstance(url, str) and url.startswith("http"):
+        return url
+    return f"https://www.youtube.com/watch?v={video_id}"
+
+
+def classify_error(stderr: str) -> str:
+    text = stderr.lower()
+    if any(term in text for term in ("private video", "sign in", "login", "cookies")):
+        return "authentication_required"
+    if any(term in text for term in ("not available in your country", "geo-restricted", "region")):
+        return "region_restricted"
+    if any(term in text for term in ("too many requests", "http error 429", "rate limit")):
+        return "rate_limited"
+    if any(term in text for term in ("video unavailable", "has been removed", "deleted")):
+        return "not_found"
+    if any(term in text for term in ("unsupported url", "unable to extract", "extractor")):
+        return "format_changed"
+    return "unavailable"
+
+
+def failure(kind: str, message: str) -> dict[str, Any]:
+    return {"schemaVersion": 1, "status": "error", "error": {"kind": kind, "message": message}}
+
+
+def clean_message(stderr: str, returncode: int) -> str:
+    lines = [line.strip() for line in stderr.splitlines() if line.strip()]
+    return lines[-1] if lines else f"yt-dlp failed with exit code {returncode}"
+
+
+def is_youtube_url(source: str) -> bool:
+    parsed = urlparse(source)
+    host = (parsed.hostname or "").lower()
+    return parsed.scheme in {"http", "https"} and (host == "youtu.be" or host == "youtube.com" or host.endswith(".youtube.com"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Probe a YouTube source as JSON without downloading media")
+    parser.add_argument("source")
+    args = parser.parse_args()
+    result = probe(args.source)
+    json.dump(result, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0 if result["status"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -52,6 +52,25 @@ def test_playlist_supports_empty_and_partially_unavailable_entries(monkeypatch):
     assert partial["warnings"][0]["kind"] == "partial_unavailable"
 
 
+def test_playlist_marks_explicitly_unavailable_entries(monkeypatch):
+    result = run(monkeypatch, {"id": "PL1", "title": "List", "entries": [
+        {"id": "v1", "title": "Private", "availability": "needs_auth"},
+        {"id": "v2", "title": "Public", "availability": "public"},
+    ]}, "https://www.youtube.com/playlist?list=PL1")
+
+    assert result["entries"][0]["available"] is False
+    assert result["entries"][1]["available"] is True
+    assert result["warnings"][0]["kind"] == "partial_unavailable"
+
+
+def test_playlist_without_entries_is_still_a_playlist(monkeypatch):
+    result = run(monkeypatch, {"id": "PL1", "title": "List"},
+                 "https://www.youtube.com/playlist?list=PL1")
+
+    assert result["sourceType"] == "playlist"
+    assert result["canonicalUrl"] == "https://www.youtube.com/playlist?list=PL1"
+
+
 def test_single_video_reports_caption_availability(monkeypatch):
     result = run(monkeypatch, {"id": "v1", "title": "Video", "webpage_url": "https://youtu.be/v1",
                                "automatic_captions": {}}, "https://www.youtube.com/watch?v=v1")
@@ -63,10 +82,25 @@ def test_single_video_reports_caption_availability(monkeypatch):
     ("Private video. Sign in", "authentication_required"),
     ("Video unavailable", "not_found"),
     ("not available in your country", "region_restricted"),
-    ("HTTP Error 429: Too Many Requests", "rate_limited"),
+    ("Sign in to confirm you are not a bot. HTTP Error 429: Too Many Requests", "rate_limited"),
     ("Unable to extract player data", "format_changed"),
 ])
 def test_structured_failures(monkeypatch, stderr, kind):
     result = run(monkeypatch, None, "https://www.youtube.com/watch?v=v1", stderr=stderr, returncode=1)
     assert result["status"] == "error"
     assert result["error"]["kind"] == kind
+
+
+def test_json_null_result_returns_structured_failure(monkeypatch):
+    monkeypatch.setattr(probe.shutil, "which", lambda _: "/usr/bin/yt-dlp")
+    result = Result()
+    result.stdout = "null"
+    monkeypatch.setattr(probe.subprocess, "run", lambda command, **kwargs: result)
+
+    value = probe.probe("https://www.youtube.com/watch?v=v1")
+
+    assert value == {
+        "schemaVersion": 1,
+        "status": "error",
+        "error": {"kind": "format_changed", "message": "yt-dlp returned an unexpected JSON value"},
+    }

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "skills" / "watch" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import probe  # noqa: E402
+
+
+class Result:
+    def __init__(self, payload=None, stderr="", returncode=0):
+        self.stdout = json.dumps(payload) if payload is not None else ""
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def run(monkeypatch, payload, source, *, stderr="", returncode=0):
+    calls = []
+    monkeypatch.setattr(probe.shutil, "which", lambda _: "/usr/bin/yt-dlp")
+    monkeypatch.setattr(probe.subprocess, "run", lambda command, **kwargs: calls.append(command) or Result(payload, stderr, returncode))
+    value = probe.probe(source)
+    assert "--skip-download" in calls[0]
+    assert "--flat-playlist" in calls[0]
+    return value
+
+
+def test_channel_probe_returns_identity_feed_and_entries(monkeypatch):
+    result = run(monkeypatch, {"id": "UC123", "channel_id": "UC123", "title": "Channel", "entries": [
+        {"id": "v1", "title": "One", "upload_date": "20260701"},
+    ]}, "https://www.youtube.com/@example/videos")
+    assert result == {
+        "schemaVersion": 1, "status": "ok", "sourceType": "channel", "platformId": "UC123",
+        "canonicalUrl": "https://www.youtube.com/channel/UC123", "title": "Channel",
+        "officialFeedUrl": "https://www.youtube.com/feeds/videos.xml?channel_id=UC123",
+        "entries": [{"id": "v1", "url": "https://www.youtube.com/watch?v=v1", "title": "One",
+                     "publishedAt": "2026-07-01T00:00:00Z", "available": True}], "warnings": [],
+    }
+
+
+def test_playlist_supports_empty_and_partially_unavailable_entries(monkeypatch):
+    empty = run(monkeypatch, {"id": "PL1", "title": "Empty", "entries": []},
+                "https://www.youtube.com/playlist?list=PL1")
+    assert empty["sourceType"] == "playlist" and empty["entries"] == []
+    partial = run(monkeypatch, {"id": "PL1", "title": "List", "entries": [None, {"id": "v2", "title": "Two"}]},
+                  "https://www.youtube.com/playlist?list=PL1")
+    assert [item["id"] for item in partial["entries"]] == ["v2"]
+    assert partial["warnings"][0]["kind"] == "partial_unavailable"
+
+
+def test_single_video_reports_caption_availability(monkeypatch):
+    result = run(monkeypatch, {"id": "v1", "title": "Video", "webpage_url": "https://youtu.be/v1",
+                               "automatic_captions": {}}, "https://www.youtube.com/watch?v=v1")
+    assert result["sourceType"] == "video"
+    assert result["entries"][0]["captionsAvailable"] is False
+
+
+@pytest.mark.parametrize(("stderr", "kind"), [
+    ("Private video. Sign in", "authentication_required"),
+    ("Video unavailable", "not_found"),
+    ("not available in your country", "region_restricted"),
+    ("HTTP Error 429: Too Many Requests", "rate_limited"),
+    ("Unable to extract player data", "format_changed"),
+])
+def test_structured_failures(monkeypatch, stderr, kind):
+    result = run(monkeypatch, None, "https://www.youtube.com/watch?v=v1", stderr=stderr, returncode=1)
+    assert result["status"] == "error"
+    assert result["error"]["kind"] == kind


### PR DESCRIPTION
## Summary

Add a machine-readable YouTube source probe for downstream tools that need stable source identity without downloading media or parsing YouTube HTML themselves.

The probe distinguishes channels, playlists, and individual videos, and returns canonical identity, titles, available entries, publication times, caption availability for single videos, and an official channel feed when yt-dlp provides a verified channel ID.

## Behavior

- emits a versioned JSON response suitable for programmatic consumers;
- uses `yt-dlp --flat-playlist --skip-download` and never downloads media;
- normalizes channel, playlist, and video results into one contract;
- preserves partial collection results and reports unavailable entries as warnings;
- returns structured error kinds for authentication, region restriction, rate limiting, missing content, extractor format changes, and general unavailability;
- rejects non-YouTube URLs before invoking yt-dlp.

## Tests

`python3 -m pytest -q`

Result: `79 passed in 4.31s`

The new tests cover channel, playlist, and video normalization, partial unavailable entries, structured failures, missing yt-dlp, and unsupported URLs.
