### PR TITLE
Fix duplicate lines from YouTube's rolling auto-caption windows

### DIFF
--- a/skills/watch/scripts/transcribe.py
+++ b/skills/watch/scripts/transcribe.py
@@ -25,7 +25,10 @@ def parse_vtt(path: str) -> list[dict]:
     text = Path(path).read_text(encoding="utf-8", errors="ignore")
     lines = text.splitlines()
 
-    segments: list[dict] = []
+    # One entry per physical cue LINE (not per cue) so _dedupe can compare
+    # lines individually — YouTube's rolling captions repeat whole lines
+    # verbatim across adjacent cues, never partial lines.
+    cue_lines: list[dict] = []
     i = 0
     while i < len(lines):
         match = TS_RE.match(lines[i])
@@ -33,37 +36,68 @@ def parse_vtt(path: str) -> list[dict]:
             i += 1
             continue
 
-        start = _to_seconds(*match.groups()[:4])
-        end = _to_seconds(*match.groups()[4:])
+        start = round(_to_seconds(*match.groups()[:4]), 2)
+        end = round(_to_seconds(*match.groups()[4:]), 2)
         i += 1
 
-        cue_lines: list[str] = []
         while i < len(lines) and lines[i].strip():
             cleaned = TAG_RE.sub("", lines[i]).strip()
             if cleaned:
-                cue_lines.append(cleaned)
+                cue_lines.append({"text": cleaned, "start": start, "end": end})
             i += 1
-
-        cue_text = " ".join(cue_lines).strip()
-        if cue_text:
-            segments.append({"start": round(start, 2), "end": round(end, 2), "text": cue_text})
         i += 1
 
-    return _dedupe(segments)
+    return _dedupe(cue_lines)
 
 
-def _dedupe(segments: list[dict]) -> list[dict]:
-    """Collapse rolling duplicates common in YouTube auto-subs."""
+MAX_SEGMENT_WORDS = 30
+MAX_SEGMENT_GAP = 1.5  # seconds of silence that force a new segment
+
+
+def _dedupe(cue_lines: list[dict]) -> list[dict]:
+    """Collapse rolling duplicates common in YouTube auto-subs and group lines
+    into readable segments.
+
+    YouTube's rolling auto-captions re-render each spoken line 2-3 times as
+    the on-screen window advances: once while it's the growing second line,
+    once settled as a solo transition cue, once again as the next cue's
+    first line. Each re-render is a verbatim repeat of the whole line, so we
+    drop a line only when it exactly matches the immediately preceding kept
+    line — never on a partial/substring match, which would risk deleting a
+    genuine spoken repetition (e.g. an idiom repeated across two distinct
+    lines) instead of a rendering artifact.
+    """
     out: list[dict] = []
-    for seg in segments:
-        if out and seg["text"] == out[-1]["text"]:
-            out[-1]["end"] = seg["end"]
+    open_seg: dict | None = None
+
+    for line in cue_lines:
+        if open_seg is not None and line["text"] == open_seg["last_line"]:
+            open_seg["end"] = line["end"]
             continue
-        if out and seg["text"].startswith(out[-1]["text"] + " "):
-            out[-1]["text"] = seg["text"]
-            out[-1]["end"] = seg["end"]
-            continue
-        out.append(seg)
+
+        start_new = (
+            open_seg is None
+            or line["start"] - open_seg["end"] > MAX_SEGMENT_GAP
+            or open_seg["word_count"] >= MAX_SEGMENT_WORDS
+        )
+        if start_new:
+            if open_seg is not None:
+                out.append({"start": open_seg["start"], "end": open_seg["end"], "text": open_seg["text"]})
+            open_seg = {
+                "start": line["start"],
+                "end": line["end"],
+                "text": line["text"],
+                "last_line": line["text"],
+                "word_count": len(line["text"].split()),
+            }
+        else:
+            open_seg["text"] += " " + line["text"]
+            open_seg["last_line"] = line["text"]
+            open_seg["word_count"] += len(line["text"].split())
+            open_seg["end"] = line["end"]
+
+    if open_seg is not None:
+        out.append({"start": open_seg["start"], "end": open_seg["end"], "text": open_seg["text"]})
     return out
 
 

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,0 +1,149 @@
+"""VTT dedup: rolling auto-caption windows, exact duplicates, segment grouping."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import transcribe
+
+
+def _parse(tmp_path: Path, vtt_text: str) -> list[dict]:
+    path = tmp_path / "captions.vtt"
+    path.write_text(vtt_text, encoding="utf-8")
+    return transcribe.parse_vtt(str(path))
+
+
+def _all_text(segments: list[dict]) -> str:
+    return " ".join(seg["text"] for seg in segments)
+
+
+# --- real rolling-window sample ----------------------------------------------
+# Actual excerpt captured from a YouTube German auto-caption VTT. Reproduces
+# the exact rolling-window 3-cue pattern: growing content cue -> ~10ms settle
+# transition -> next growing content cue whose first line repeats the settled
+# text.
+ROLLING_SAMPLE_VTT = """WEBVTT
+Kind: captions
+Language: de
+
+00:00:07.069 --> 00:00:09.470 align:start position:0%
+[Musik]
+ich<00:00:08.069><c> begrüße</c><00:00:08.429><c> ich</c><00:00:08.460><c> herzlich</c><00:00:09.000><c> zu</c><00:00:09.090><c> einer</c><00:00:09.210><c> neuen</c>
+
+00:00:09.470 --> 00:00:09.480 align:start position:0%
+ich begrüße ich herzlich zu einer neuen
+
+
+00:00:09.480 --> 00:00:11.810 align:start position:0%
+ich begrüße ich herzlich zu einer neuen
+folge<00:00:09.840><c> von</c><00:00:10.050><c> alpha</c><00:00:10.710><c> baby</c><00:00:11.099><c> mein</c><00:00:11.400><c> name</c><00:00:11.670><c> ist</c>
+
+00:00:11.810 --> 00:00:11.820 align:start position:0%
+folge von alpha baby mein name ist
+
+
+00:00:11.820 --> 00:00:13.910 align:start position:0%
+folge von alpha baby mein name ist
+antrag<00:00:12.210><c> fabry</c><00:00:12.570><c> und</c><00:00:12.809><c> als</c><00:00:13.349><c> astrologin</c>
+"""
+
+
+def test_rolling_window_line_appears_once(tmp_path):
+    segments = _parse(tmp_path, ROLLING_SAMPLE_VTT)
+    combined = _all_text(segments)
+    for phrase in [
+        "ich begrüße ich herzlich zu einer neuen",
+        "folge von alpha baby mein name ist",
+    ]:
+        assert combined.count(phrase) == 1, f"expected {phrase!r} once, found in: {combined!r}"
+
+
+def test_rolling_window_reconstructs_full_sentence(tmp_path):
+    segments = _parse(tmp_path, ROLLING_SAMPLE_VTT)
+    assert _all_text(segments) == (
+        "[Musik] ich begrüße ich herzlich zu einer neuen "
+        "folge von alpha baby mein name ist antrag fabry und als astrologin"
+    )
+
+
+def test_rolling_window_timestamps_stay_monotonic(tmp_path):
+    segments = _parse(tmp_path, ROLLING_SAMPLE_VTT)
+    assert segments
+    prev_end = -1.0
+    for seg in segments:
+        assert seg["start"] >= prev_end
+        assert seg["end"] >= seg["start"]
+        prev_end = seg["end"]
+    assert segments[0]["start"] >= 7.0
+    assert segments[-1]["end"] <= 13.91
+
+
+# --- exact-duplicate case (already handled pre-fix, must keep working) ------
+
+EXACT_DUPLICATE_VTT = """WEBVTT
+
+00:00:01.000 --> 00:00:02.000
+Hallo zusammen
+
+00:00:02.000 --> 00:00:03.000
+Hallo zusammen
+
+00:00:03.000 --> 00:00:05.000
+und willkommen
+"""
+
+
+def test_identical_consecutive_lines_collapse_once(tmp_path):
+    combined = _all_text(_parse(tmp_path, EXACT_DUPLICATE_VTT))
+    assert combined.count("Hallo zusammen") == 1
+    assert "und willkommen" in combined
+
+
+# --- safety case: a genuine spoken repetition must survive -------------------
+# Only a fully identical line is ever collapsed - a partial/substring overlap
+# (e.g. an idiom repeated across two distinct, non-identical lines) is not
+# enough, so it's never mistaken for a rolling-caption artifact.
+
+GENUINE_REPETITION_VTT = """WEBVTT
+
+00:00:01.000 --> 00:00:03.000
+das war das erste Mal dass ich sowas erlebt habe
+
+00:00:03.000 --> 00:00:05.000
+das erste Mal war ich total überrascht
+"""
+
+
+def test_repeated_idiom_across_distinct_lines_not_dropped(tmp_path):
+    combined = _all_text(_parse(tmp_path, GENUINE_REPETITION_VTT))
+    assert combined.count("das erste Mal") == 2
+    assert "das war das erste Mal dass ich sowas erlebt habe" in combined
+    assert "das erste Mal war ich total überrascht" in combined
+
+
+# --- segment grouping ---------------------------------------------------------
+
+def test_long_silence_starts_a_new_segment(tmp_path):
+    vtt = """WEBVTT
+
+00:00:01.000 --> 00:00:02.000
+erste Zeile
+
+00:00:10.000 --> 00:00:11.000
+zweite Zeile nach einer Pause
+"""
+    assert len(_parse(tmp_path, vtt)) == 2
+
+
+def test_long_continuous_speech_is_chunked(tmp_path):
+    lines = []
+    t = 0.0
+    for i in range(40):
+        start, end = t, t + 0.5
+        lines.append(f"00:00:{start:06.3f} --> 00:00:{end:06.3f}\nwort{i}\n")
+        t = end
+    vtt = "WEBVTT\n\n" + "\n".join(lines)
+    segments = _parse(tmp_path, vtt)
+    assert len(segments) > 1, "40 words with no repeats should split into multiple segments"
+    tokens = _all_text(segments).split()
+    for i in range(40):
+        assert tokens.count(f"wort{i}") == 1


### PR DESCRIPTION
## Summary
Fix duplicate transcript lines caused by YouTube's rolling auto-caption windows re-rendering each line 2-3 times. The old dedup only checked whether a cue's text was a *prefix* of the previous cue, so it never caught the transition cue repeating the tail of what came before — every spoken line ended up duplicated once at the end of one segment and again at the start of the next.

Rewritten to compare whole cue *lines* against the single immediately-preceding kept line, collapsing only on an exact match — never a partial/word-overlap match, so a genuine spoken repetition split across two different lines (e.g. an idiom said twice) is never mistaken for a rendering artifact.

## Test plan
- [x] Regression tests added in `tests/test_transcribe.py`: the real rolling-caption pattern captured from a live YouTube auto-caption file, the pre-existing exact-duplicate case, a dedicated safety case for genuine spoken repetition, and segment-grouping behavior.
- [x] Verified end-to-end against a real German YouTube video: deduped transcript (29 segments, full video) has no duplicated phrases and matches an independently Whisper-transcribed version of the same video.
- [x] Full pytest suite: no regressions (pre-existing local ffmpeg-fixture errors are unrelated, present identically on unmodified `main`).

---
**Update:** Rebased onto the `skills/watch/` restructure (0.2.0) and reduced to just this fix — an earlier version of this PR also included subtitle-language auto-detection, but that conflicts with the deliberate English-only design guarded by `tests/test_download.py`, so it's been dropped from this PR to keep it focused on the uncontroversial bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)