### PR TITLE
Fix frame extraction on ffmpeg 9.0+ (-vsync was removed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `/watch` are documented here.
 
+## [Unreleased]
+
+### Fixed
+- **Frame extraction on ffmpeg 9.0+.** Both extraction paths passed `-vsync`, which ffmpeg removed in 9.0, so every `efficient`, `balanced`, and `token-burner` run failed with `Unrecognized option 'vsync'`. Switched to the modern equivalent `-fps_mode vfr` (available since ffmpeg 5.0). `--detail transcript` was unaffected.
+
 ## [0.2.0] — 2026-06-29
 
 ### Added

--- a/skills/watch/scripts/frames.py
+++ b/skills/watch/scripts/frames.py
@@ -253,7 +253,7 @@ def extract_scene_candidates(
     cmd += [
         "-i", str(Path(video_path).resolve()),
         "-vf", vf,
-        "-vsync", "vfr",
+        "-fps_mode", "vfr",
     ]
     if max_frames is not None:
         cmd += ["-frames:v", str(max_frames)]
@@ -612,7 +612,7 @@ def extract_keyframes(
         "-skip_frame", "nokey",
         "-i", str(Path(video_path).resolve()),
         "-vf", f"{_scale_filter(resolution)},showinfo",
-        "-vsync", "vfr",
+        "-fps_mode", "vfr",
         "-q:v", "4",
         output_pattern,
     ]


### PR DESCRIPTION
## The bug

ffmpeg 9.0 removed the long-deprecated `-vsync` option. `frames.py` passes it in both extraction paths, so on ffmpeg 9.x **every frame mode fails immediately**:

```
[watch] extracting keyframes over 00:00-00:12 (12.0s) (target 4, cap 4)…
ffmpeg keyframe extraction failed: Unrecognized option 'vsync'.
Error splitting the argument list: Option not found
```

This hits `--detail efficient`, `balanced` (the default), and `token-burner`. Only `--detail transcript` still works, since it extracts no frames.

## Why this is reachable from a clean install

`winget install Gyan.FFmpeg` on Windows currently resolves to **9.0**, so following the documented Windows setup path produces a `/watch` that cannot extract a single frame.

It also fails quietly in the worst way: `setup.py --check` still exits 0 and reports ready, because preflight only verifies the binaries are on `PATH`, not that the flags parse. The first sign of trouble is a failed run.

## The fix

`-vsync vfr` → `-fps_mode vfr` in the two call sites (`extract_scene_candidates`, `extract_keyframes`).

`-fps_mode` is the documented modern equivalent, added in **ffmpeg 5.0**, so this doesn't raise the floor for anyone on a currently-supported release. Behavior is unchanged.

## Testing

Verified on Windows 11, Python 3.13, ffmpeg 9.0-full_build (Gyan), yt-dlp 2026.07.04, against a real YouTube download:

| Path | Before | After |
|---|---|---|
| `--detail efficient` | `Unrecognized option 'vsync'` | 4 frames, `reason=keyframe`, t=00:00→00:08 |
| `--detail balanced` | `Unrecognized option 'vsync'` | 9 scene candidates → 3 sampled, `first-frame` + `scene-change` |
| `--detail transcript` | worked | worked |

Extracted JPEGs render correctly through the `Read` tool, and timestamps line up with the source. No test changes needed — the suite doesn't assert on this flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
