### PR TITLE
Replace removed `-vsync` with `-fps_mode` for ffmpeg 8+

### DIFF
--- a/skills/watch/scripts/frames.py
+++ b/skills/watch/scripts/frames.py
@@ -253,7 +253,7 @@ def extract_scene_candidates(
     cmd += [
         "-i", str(Path(video_path).resolve()),
         "-vf", vf,
-        "-vsync", "vfr",
+        "-fps_mode", "vfr",
     ]
     if max_frames is not None:
         cmd += ["-frames:v", str(max_frames)]
@@ -612,7 +612,7 @@ def extract_keyframes(
         "-skip_frame", "nokey",
         "-i", str(Path(video_path).resolve()),
         "-vf", f"{_scale_filter(resolution)},showinfo",
-        "-vsync", "vfr",
+        "-fps_mode", "vfr",
         "-q:v", "4",
         output_pattern,
     ]


### PR DESCRIPTION

## Problem

ffmpeg deprecated `-vsync` in 5.0 and **removed** it in 8.0. On ffmpeg 8 or newer, both frame-extraction paths in `frames.py` abort before producing a single frame:

```
Unrecognized option 'vsync'.
Error splitting the argument list: Option not found
```

The user sees `ffmpeg scene extraction failed` and `/watch` silently degrades to transcript-only on **every** video. Anyone who installed ffmpeg recently — `brew install ffmpeg`, `winget install Gyan.FFmpeg`, most current distro packages — hits this on their first run.

## Fix

`-vsync vfr` → `-fps_mode vfr` in both places (`extract_scene_candidates` and the keyframe extractor).

`-fps_mode` is the documented replacement and has been accepted since ffmpeg **5.0** (2022), so this does not raise the floor for anyone who was previously working.

## Test evidence

Running the existing suite on Windows with ffmpeg 9.0.1 (Gyan build), Python 3.13:

| Branch | Result |
|---|---|
| `main` | **22 failed**, 49 passed |
| this branch | **3 failed**, 68 passed |

The 22 failures on `main` are the `-vsync` breakage cascading through every test that extracts a frame.

## Remaining failures — not addressed here

Three failures survive the fix. Both look like pre-existing Windows issues rather than anything this PR touches, and I've deliberately left them out of scope:

1. `test_setup.py::test_keyless_completed_setup_proceeds_silently` — `setup.py` emits `WARNING: ... is readable by other users. Run: chmod 600 ...` on every invocation. The permission check assumes POSIX mode bits, so on Windows it always fires, which breaks the "silent on success" contract. The suggested `chmod 600` is also not meaningful advice on Windows.

2. `test_watch.py::test_dedup_collapses_static_by_default` and `test_no_dedup_preserves_static_frames` — the static-clip fixture yields **0** frames where the test expects 1. Note this changes failure *mode* rather than being fixed by this PR: on `main` it fails inside ffmpeg on `-vsync`; here it fails on an empty frame set. Worth a separate look — I didn't want to guess at the intended behaviour.

Happy to open follow-ups for either if useful.

## Environment

- Windows 10, Python 3.13.15
- ffmpeg 9.0.1-full_build (Gyan)
- yt-dlp 2026.08.19
