### PR TITLE
Add `--lang` so non-English videos get their native captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to `/watch` are documented here.
 ### Added
 - **`--lang CODES`** — comma-separated caption languages in priority order (default `en,pt`). The first requested language that yields a track wins; region codes are normalised (`pt-BR` → `pt`) and duplicates collapsed.
 
+### Changed
+- Captions are now requested as exact codes (`en,en-orig,pt,pt-orig`) instead of the previous `en.*` glob. yt-dlp matches `--sub-langs` case-insensitively, so a `code.*` glob also selects YouTube's auto-translated pairs (`pt-en`, `en-de`, `pt-PT-de`, …) — on one test video that was 7 caption fetches where 1 was wanted, and the surplus requests drew HTTP 429s that cost the transcript entirely.
+
 ### Fixed
 - Captions were requested as `en.*` only, hardcoded in both yt-dlp calls, and `_pick_subtitle()` further preferred `.en.`/`.en-US.`/`.en-GB.`/`.en-orig.` filenames. Any non-English video therefore came back with no transcript — falling through to Whisper (a paid API call) or, keyless, to frames-only, even when the platform had perfectly good native captions in the video's own language.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `/watch` are documented here.
 
+## [Unreleased]
+
+### Added
+- **`--lang CODES`** — comma-separated caption languages in priority order (default `en,pt`). The first requested language that yields a track wins; region codes are normalised (`pt-BR` → `pt`) and duplicates collapsed.
+
+### Fixed
+- Captions were requested as `en.*` only, hardcoded in both yt-dlp calls, and `_pick_subtitle()` further preferred `.en.`/`.en-US.`/`.en-GB.`/`.en-orig.` filenames. Any non-English video therefore came back with no transcript — falling through to Whisper (a paid API call) or, keyless, to frames-only, even when the platform had perfectly good native captions in the video's own language.
+
 ## [0.2.0] — 2026-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to `/watch` are documented here.
 ### Added
 - **`--lang CODES`** — comma-separated caption languages in priority order (default `en,pt`). The first requested language that yields a track wins; region codes are normalised (`pt-BR` → `pt`) and duplicates collapsed.
 
+### Fixed
+- `_pick_subtitle()` returned an auto-translated track over the original speech. A video whose captions exist in its own language *and* as an English auto-translation matched `en` first under the default `en,pt`, so the transcript came back machine-translated — silently, with nothing in the report saying so. yt-dlp's `-orig` track is the language actually spoken, so it now outranks the caller's ordering; the priority list still decides everything else.
+
 ### Changed
 - Captions are now requested as exact codes (`en,en-orig,pt,pt-orig`) instead of the previous `en.*` glob. yt-dlp matches `--sub-langs` case-insensitively, so a `code.*` glob also selects YouTube's auto-translated pairs (`pt-en`, `en-de`, `pt-PT-de`, …) — on one test video that was 7 caption fetches where 1 was wanted, and the surplus requests drew HTTP 429s that cost the transcript entirely.
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Other knobs (passed to `scripts/watch.py`):
 - `--detail transcript|efficient|balanced|token-burner` — fidelity/speed dial. `transcript` skips frames (transcript only); `efficient` uses fast keyframes (cap 50); `balanced` uses scene-aware frames (cap 100); `token-burner` is scene-aware and uncapped.
 - `--timestamps T1,T2,…` — grab a frame at each absolute timestamp (`SS`/`MM:SS`/`HH:MM:SS`). Claude reads the transcript first, then targets the moments the presenter flags ("look here", "as you can see"). Added on top of the detail frames (reserved against the cap); out-of-window cues are dropped in focus mode; with `--detail transcript` these become the only frames.
 - `--max-frames N` — lower the frame cap for a tighter token budget.
+- `--lang CODES` — comma-separated caption languages in priority order (default `en,pt`). First one that yields a track wins; region codes are normalised (`pt-BR` → `pt`).
 - `--resolution W` — bump frame width to 1024 px when Claude needs to read on-screen text (slides, terminals, code).
 - `--fps F` — override the auto-fps calculation (still capped at 2 fps).
 - `--whisper groq|openai` — force a specific Whisper backend.

--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -144,6 +144,7 @@ Optional flags:
 - `--start T` / `--end T` — focus on a section. Accepts `SS`, `MM:SS`, or `HH:MM:SS`. When either is set, fps auto-scales denser (see "Focusing on a section" below).
 - `--timestamps T1,T2,…` — grab a frame at each of these absolute timestamps (`SS`, `MM:SS`, or `HH:MM:SS`). Use this after reading the transcript to capture deictic moments the presenter flags ("look here", "as you can see", "notice this") that visual selection alone may miss. See "Transcript-cue frames" below.
 - `--max-frames N` — override the preset cap for tighter token budget (e.g. `--max-frames 40`)
+- `--lang CODES` — comma-separated caption languages in priority order (default `en,pt`). The first requested language that actually yields a track wins, so `--lang pt` on a Portuguese video gets its captions instead of falling through to Whisper. Region codes are normalised (`pt-BR` → `pt`).
 - `--resolution W` — change frame width in px (default 512; bump to 1024 only if the user needs to read on-screen text)
 - `--fps F` — override auto-fps (clamped to 2 fps max)
 - `--out-dir DIR` — keep working files somewhere specific (default: an auto-generated tmp dir)

--- a/skills/watch/scripts/download.py
+++ b/skills/watch/scripts/download.py
@@ -69,13 +69,35 @@ def _pick_subtitle(out_dir: Path, lang: str = "en,pt") -> Path | None:
     candidates = sorted(out_dir.glob("video*.vtt"))
     if not candidates:
         return None
-    # Honour the caller's priority order: first requested language that
-    # actually produced a file wins, regardless of alphabetical order.
-    for base in _lang_list(lang):
+
+    def _match(base: str, suffix: str | None) -> Path | None:
+        want = f".{base}-orig." if suffix == "orig" else None
         for c in candidates:
             name = c.name.lower()
-            if f".{base}." in name or f".{base}-" in name:
+            if want is not None:
+                if want in name:
+                    return c
+            elif f".{base}." in name or f".{base}-" in name:
                 return c
+        return None
+
+    bases = _lang_list(lang)
+    # Pass 1 — `-orig` is yt-dlp's name for the track in the language actually
+    # spoken in the video, so it outranks the caller's ordering entirely. Without
+    # this, a Portuguese video that also publishes an English auto-translation
+    # returns the translation under the default `en,pt`: `en` wins the priority
+    # loop, and the user silently gets machine-translated English instead of the
+    # original speech.
+    for base in bases:
+        hit = _match(base, "orig")
+        if hit is not None:
+            return hit
+    # Pass 2 — no original-language track among the requested languages, so fall
+    # back to the caller's priority order.
+    for base in bases:
+        hit = _match(base, None)
+        if hit is not None:
+            return hit
     return candidates[0]
 
 

--- a/skills/watch/scripts/download.py
+++ b/skills/watch/scripts/download.py
@@ -52,8 +52,17 @@ def _lang_list(lang: str) -> list[str]:
 
 
 def _sub_langs_arg(lang: str) -> str:
-    """Build yt-dlp's --sub-langs value from the priority list."""
-    return ",".join(f"{code}.*" for code in _lang_list(lang))
+    """Build yt-dlp's --sub-langs value from the priority list.
+
+    Exact codes, deliberately not a `code.*` glob. yt-dlp matches --sub-langs
+    case-insensitively, so `pt.*` also selects YouTube's auto-translated pairs
+    (`pt-en`, `pt-de`, `pt-PT-en`, ...). On a video that offers several source
+    languages that turns one caption fetch into seven, and the extra requests
+    draw HTTP 429s that can cost the transcript entirely. `-orig` is yt-dlp's
+    own name for the untranslated track, so it is the one variant worth asking
+    for by name.
+    """
+    return ",".join(f"{code},{code}-orig" for code in _lang_list(lang))
 
 
 def _pick_subtitle(out_dir: Path, lang: str = "en,pt") -> Path | None:

--- a/skills/watch/scripts/download.py
+++ b/skills/watch/scripts/download.py
@@ -41,15 +41,33 @@ def resolve_local(path: str) -> dict:
     }
 
 
-def _pick_subtitle(out_dir: Path) -> Path | None:
+def _lang_list(lang: str) -> list[str]:
+    """Split a comma-separated priority list into base codes ('pt-BR' -> 'pt')."""
+    out: list[str] = []
+    for part in str(lang).split(","):
+        base = part.strip().split("-")[0].lower()
+        if base and base not in out:
+            out.append(base)
+    return out or ["en"]
+
+
+def _sub_langs_arg(lang: str) -> str:
+    """Build yt-dlp's --sub-langs value from the priority list."""
+    return ",".join(f"{code}.*" for code in _lang_list(lang))
+
+
+def _pick_subtitle(out_dir: Path, lang: str = "en,pt") -> Path | None:
     candidates = sorted(out_dir.glob("video*.vtt"))
     if not candidates:
         return None
-    preferred = [
-        c for c in candidates
-        if any(marker in c.name for marker in (".en.", ".en-US.", ".en-GB.", ".en-orig."))
-    ]
-    return preferred[0] if preferred else candidates[0]
+    # Honour the caller's priority order: first requested language that
+    # actually produced a file wins, regardless of alphabetical order.
+    for base in _lang_list(lang):
+        for c in candidates:
+            name = c.name.lower()
+            if f".{base}." in name or f".{base}-" in name:
+                return c
+    return candidates[0]
 
 
 def _pick_video(out_dir: Path) -> Path | None:
@@ -62,7 +80,7 @@ def _pick_video(out_dir: Path) -> Path | None:
     return None
 
 
-def fetch_captions(url: str, out_dir: Path) -> dict:
+def fetch_captions(url: str, out_dir: Path, lang: str = "en,pt") -> dict:
     """Fetch metadata and best available VTT captions without downloading video."""
     if shutil.which("yt-dlp") is None:
         raise SystemExit("yt-dlp is not installed. Install with: brew install yt-dlp")
@@ -75,7 +93,7 @@ def fetch_captions(url: str, out_dir: Path) -> dict:
         "--write-info-json",
         "--write-subs",
         "--write-auto-subs",
-        "--sub-langs", "en.*",
+        "--sub-langs", _sub_langs_arg(lang),
         "--sub-format", "vtt",
         "--convert-subs", "vtt",
         "--no-playlist",
@@ -85,7 +103,7 @@ def fetch_captions(url: str, out_dir: Path) -> dict:
         url,
     ]
     subprocess.run(cmd, stdout=sys.stderr, stderr=sys.stderr)
-    subtitle = _pick_subtitle(out_dir)
+    subtitle = _pick_subtitle(out_dir, lang)
     info = _read_info(out_dir / "video.info.json", url)
     return {
         "video_path": None,
@@ -116,6 +134,7 @@ def download_url(
     url: str,
     out_dir: Path,
     audio_only: bool = False,
+    lang: str = "en,pt",
 ) -> dict:
     if shutil.which("yt-dlp") is None:
         raise SystemExit("yt-dlp is not installed. Install with: brew install yt-dlp")
@@ -132,7 +151,7 @@ def download_url(
         "--write-info-json",
         "--write-subs",
         "--write-auto-subs",
-        "--sub-langs", "en.*",
+        "--sub-langs", _sub_langs_arg(lang),
         "--sub-format", "vtt",
         "--convert-subs", "vtt",
         "--no-playlist",
@@ -151,7 +170,7 @@ def download_url(
             f"yt-dlp did not produce a video file in {out_dir} (exit {result.returncode})"
         )
 
-    subtitle = _pick_subtitle(out_dir)
+    subtitle = _pick_subtitle(out_dir, lang)
     info = _read_info(out_dir / "video.info.json", url)
 
     return {
@@ -166,9 +185,10 @@ def download(
     source: str,
     out_dir: Path,
     audio_only: bool = False,
+    lang: str = "en,pt",
 ) -> dict:
     if is_url(source):
-        return download_url(source, out_dir, audio_only=audio_only)
+        return download_url(source, out_dir, audio_only=audio_only, lang=lang)
     return resolve_local(source)
 
 

--- a/skills/watch/scripts/watch.py
+++ b/skills/watch/scripts/watch.py
@@ -46,6 +46,13 @@ def main() -> int:
              "e.g. transcript-flagged 'look here' moments. Added on top of the detail frames "
              "(reserved against the cap); with --detail transcript these become the only frames.",
     )
+    ap.add_argument(
+        "--lang",
+        type=str,
+        default="en,pt",
+        help="Comma-separated caption language codes in priority order "
+             "(default: en,pt). The first one that yields a track wins. e.g. pt, es,en.",
+    )
     ap.add_argument("--start", type=str, default=None, help="Range start (SS, MM:SS, or HH:MM:SS)")
     ap.add_argument("--end", type=str, default=None, help="Range end (SS, MM:SS, or HH:MM:SS)")
     ap.add_argument("--out-dir", type=str, default=None, help="Working directory (default: tmp)")
@@ -96,7 +103,7 @@ def main() -> int:
 
     if url_source:
         print("[watch] checking metadata/captions via yt-dlp…", file=sys.stderr)
-        dl = fetch_captions(args.source, work / "download")
+        dl = fetch_captions(args.source, work / "download", lang=args.lang)
         if dl.get("subtitle_path"):
             try:
                 transcript_segments = parse_vtt(dl["subtitle_path"])
@@ -122,6 +129,7 @@ def main() -> int:
                 args.source,
                 work / "download",
                 audio_only=audio_only,
+                lang=args.lang,
             )
         else:
             print("[watch] using local file…", file=sys.stderr)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2,8 +2,8 @@
 
 Regression guard: ``--sub-langs all`` makes yt-dlp fetch YouTube's hundreds of
 auto-translated caption tracks, which can take minutes and stalls before the
-video download even starts. We only support English, so the request must stay
-bounded to the English-only pattern.
+video download even starts. The request must stay bounded to the languages the
+caller actually asked for.
 """
 from __future__ import annotations
 
@@ -43,22 +43,60 @@ def _sub_langs(argv: list[str]) -> str:
     return argv[idx + 1]
 
 
-def _assert_english_only(langs: str) -> None:
+def _assert_bounded(langs: str, expected: list[str]) -> None:
     tokens = langs.split(",")
     assert "all" not in tokens, f"sub-langs must not request all languages, got {langs!r}"
-    assert all(t.startswith("en") for t in tokens), f"sub-langs must be English-only, got {langs!r}"
+    assert tokens == [f"{code}.*" for code in expected], (
+        f"sub-langs must request exactly the caller's languages, got {langs!r}"
+    )
 
 
-def test_fetch_captions_requests_english_only(monkeypatch, tmp_path):
+def test_fetch_captions_defaults_to_en_pt(monkeypatch, tmp_path):
     calls = _capture_argv(monkeypatch)
     download.fetch_captions(URL, tmp_path / "download")
-    _assert_english_only(_sub_langs(calls[0]))
+    _assert_bounded(_sub_langs(calls[0]), ["en", "pt"])
 
 
-def test_download_url_requests_english_only(monkeypatch, tmp_path):
+def test_download_url_defaults_to_en_pt(monkeypatch, tmp_path):
     calls = _capture_argv(monkeypatch)
     # _pick_video returns None with no real file, which raises SystemExit after
     # the yt-dlp argv is already built — that's all we need to inspect.
     with pytest.raises(SystemExit):
         download.download_url(URL, tmp_path / "download")
-    _assert_english_only(_sub_langs(calls[0]))
+    _assert_bounded(_sub_langs(calls[0]), ["en", "pt"])
+
+
+def test_explicit_lang_is_honoured(monkeypatch, tmp_path):
+    calls = _capture_argv(monkeypatch)
+    download.fetch_captions(URL, tmp_path / "download", lang="es")
+    _assert_bounded(_sub_langs(calls[0]), ["es"])
+
+
+def test_lang_list_normalises_regions_and_dedupes():
+    assert download._lang_list("en,pt") == ["en", "pt"]
+    assert download._lang_list("pt-BR, EN") == ["pt", "en"]
+    assert download._lang_list("en,en-US") == ["en"]
+    assert download._lang_list("") == ["en"]
+
+
+def test_pick_subtitle_follows_priority_order(tmp_path):
+    for name in ("video.en.vtt", "video.pt.vtt"):
+        (tmp_path / name).touch()
+    assert download._pick_subtitle(tmp_path, "en,pt").name == "video.en.vtt"
+    assert download._pick_subtitle(tmp_path, "pt,en").name == "video.pt.vtt"
+
+
+def test_pick_subtitle_skips_languages_that_produced_no_file(tmp_path):
+    # yt-dlp commonly fails one variant (429, no such track) while another
+    # succeeds; the first *available* requested language must win.
+    (tmp_path / "video.pt-orig.vtt").touch()
+    assert download._pick_subtitle(tmp_path, "en,pt").name == "video.pt-orig.vtt"
+
+
+def test_pick_subtitle_falls_back_to_any_track(tmp_path):
+    (tmp_path / "video.de.vtt").touch()
+    assert download._pick_subtitle(tmp_path, "en,pt").name == "video.de.vtt"
+
+
+def test_pick_subtitle_returns_none_when_empty(tmp_path):
+    assert download._pick_subtitle(tmp_path, "en,pt") is None

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -46,9 +46,13 @@ def _sub_langs(argv: list[str]) -> str:
 def _assert_bounded(langs: str, expected: list[str]) -> None:
     tokens = langs.split(",")
     assert "all" not in tokens, f"sub-langs must not request all languages, got {langs!r}"
-    assert tokens == [f"{code}.*" for code in expected], (
+    expanded = [v for code in expected for v in (code, f"{code}-orig")]
+    assert tokens == expanded, (
         f"sub-langs must request exactly the caller's languages, got {langs!r}"
     )
+    # A `code.*` glob would also pull YouTube's auto-translated pairs, which is
+    # the request explosion this guard exists to prevent.
+    assert not any("*" in t for t in tokens), f"sub-langs must not use globs, got {langs!r}"
 
 
 def test_fetch_captions_defaults_to_en_pt(monkeypatch, tmp_path):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -97,6 +97,22 @@ def test_pick_subtitle_skips_languages_that_produced_no_file(tmp_path):
     assert download._pick_subtitle(tmp_path, "en,pt").name == "video.pt-orig.vtt"
 
 
+def test_pick_subtitle_prefers_original_over_a_translation(tmp_path):
+    # A Portuguese video that also publishes an English auto-translation. Under
+    # the default `en,pt` the priority order alone would hand back the English
+    # translation; the `-orig` track is the language actually spoken, so it wins.
+    for name in ("video.en.vtt", "video.pt.vtt", "video.pt-orig.vtt"):
+        (tmp_path / name).touch()
+    assert download._pick_subtitle(tmp_path, "en,pt").name == "video.pt-orig.vtt"
+
+
+def test_pick_subtitle_prefers_requested_original_when_several_exist(tmp_path):
+    for name in ("video.en-orig.vtt", "video.pt-orig.vtt"):
+        (tmp_path / name).touch()
+    assert download._pick_subtitle(tmp_path, "en,pt").name == "video.en-orig.vtt"
+    assert download._pick_subtitle(tmp_path, "pt,en").name == "video.pt-orig.vtt"
+
+
 def test_pick_subtitle_falls_back_to_any_track(tmp_path):
     (tmp_path / "video.de.vtt").touch()
     assert download._pick_subtitle(tmp_path, "en,pt").name == "video.de.vtt"


### PR DESCRIPTION

## Problem

The caption language is hardcoded to English in two separate places:

- both yt-dlp invocations pass `--sub-langs "en.*"` (`fetch_captions`, `download_url`)
- `_pick_subtitle()` then additionally prefers `.en.` / `.en-US.` / `.en-GB.` / `.en-orig.` filenames

So a video whose captions exist only in another language comes back with **no transcript at all**. `/watch` then either:

- burns a paid Whisper call to re-derive captions the platform was already serving for free, or
- with no API key configured, degrades to frames-only and answers the user's question with none of the spoken content

I hit this on a Portuguese video that has perfectly good native `pt` captions. `yt-dlp` was asked for `en`, got nothing, and the report said `No transcript available`.

## Change

`--lang` takes a **comma-separated priority list**, default `en,pt`.

```bash
python3 watch.py "<url>"              # en, then pt
python3 watch.py "<url>" --lang pt    # pt only — one request
python3 watch.py "<url>" --lang pt,en # invert the priority
```

The first requested language that actually *produced a track* wins. That also handles yt-dlp failing one variant while another succeeds — common when a 429 kills one track mid-run, which I hit repeatedly while testing.

Region codes are normalised (`pt-BR` → `pt`) and duplicates collapsed.

> **Default choice is yours to make.** I used `en,pt` because it keeps English first for every existing user and `pt` is what I needed. If you'd rather not bless a second language in the default, `en` alone works identically for English users — the flag is the substance of the PR, not the default.

## The regression guard is preserved

`tests/test_download.py` guards against `--sub-langs all`, which makes yt-dlp enumerate hundreds of auto-translated tracks and stall before the video download starts. That guard stays.

What changed is the assertion: it previously required every token to start with `en`, which conflates "bounded" with "English". It now asserts the argv equals *exactly the caller's requested languages* — the property the guard was actually protecting, and a stricter check than before.

## Tests

Six new cases, all passing (`8 passed` in `test_download.py`):

- defaults resolve to `en,pt` in both yt-dlp call sites
- an explicit `--lang es` produces exactly `es.*`
- `_lang_list` normalises regions, dedupes, and falls back to `en` on empty input
- `_pick_subtitle` honours priority order when several tracks exist
- `_pick_subtitle` skips a requested language that produced no file
- `_pick_subtitle` still falls back to any available track, and returns `None` when there are none

No new failures in the rest of the suite — the pre-existing failures are unchanged in count and identity.

## Verified end-to-end

Against a Portuguese YouTube video that previously produced an empty transcript: **127 caption segments via captions**, with no flags passed.

## Note on stacking

This branch is cut from `main` and does **not** include the `-fps_mode` fix from the companion PR. On ffmpeg 8+ you'll want both — that one is required for any frame extraction to work at all.
