### PR TITLE
Fix two Windows-only test failures (permissions warning, path separator)

### DIFF
--- a/skills/watch/scripts/frames.py
+++ b/skills/watch/scripts/frames.py
@@ -253,7 +253,7 @@ def extract_scene_candidates(
     cmd += [
         "-i", str(Path(video_path).resolve()),
         "-vf", vf,
-        "-vsync", "vfr",
+        "-fps_mode", "vfr",
     ]
     if max_frames is not None:
         cmd += ["-frames:v", str(max_frames)]
@@ -612,7 +612,7 @@ def extract_keyframes(
         "-skip_frame", "nokey",
         "-i", str(Path(video_path).resolve()),
         "-vf", f"{_scale_filter(resolution)},showinfo",
-        "-vsync", "vfr",
+        "-fps_mode", "vfr",
         "-q:v", "4",
         output_pattern,
     ]

--- a/skills/watch/scripts/setup.py
+++ b/skills/watch/scripts/setup.py
@@ -72,7 +72,16 @@ _PERM_WARNED: set[str] = set()
 
 def _check_file_permissions(path: Path) -> None:
     """Warn to stderr (once per path per process) if a secrets file is
-    world/group readable."""
+    world/group readable.
+
+    POSIX only. Windows does not implement the group/other mode bits: st_mode
+    reports 0o666 for any writable file no matter how the ACL is actually set,
+    so this check fires on every single run there. That both breaks the
+    "silent on success" contract of `--check` and hands the user a `chmod 600`
+    that would not do anything on their platform.
+    """
+    if os.name == "nt":
+        return
     key = str(path)
     if key in _PERM_WARNED:
         return

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -70,7 +71,13 @@ def test_timestamps_with_transcript_detail_is_cue_only(cut_clip: Path):
 
 
 def _frame_lines(out: str) -> int:
-    return sum(1 for line in out.splitlines() if "/frames/frame_" in line and "(t=" in line)
+    # The report prints native paths, so the separator is "\" on Windows and
+    # "/" elsewhere. Matching only "/" counted zero frames on Windows and made
+    # these assertions fail on a run that had produced frames correctly.
+    return sum(
+        1 for line in out.splitlines()
+        if re.search(r"[\\/]frames[\\/]frame_", line) and "(t=" in line
+    )
 
 
 def test_dedup_collapses_static_by_default(static_clip: Path):


### PR DESCRIPTION
Follow-up to #186, which I said I'd file if the remaining failures turned out to be worth fixing. They were, and neither is a logic bug — both are portability issues invisible on macOS/Linux.

## 1. `setup.py` warns about file permissions on every Windows run

`_check_file_permissions()` warns when `st_mode & 0o044`. Windows does not implement the group/other mode bits — `st_mode` reports `0o666` for any writable file no matter what the actual ACL says — so the warning fires unconditionally:

```
[watch] WARNING: C:\Users\...\.config\watch\.env is readable by other users.
Run: chmod 600 C:\Users\...\.config\watch\.env
```

Two problems with that:

- It breaks the **silent-on-success contract** that `SKILL.md` documents for `--check` ("On exit 0 the script emits **nothing** — proceed to Step 1 without comment"), and that `test_keyless_completed_setup_proceeds_silently` asserts. Every `/watch` invocation printed a spurious warning.
- The remedy it suggests, `chmod 600`, does nothing on Windows. The `CONFIG_FILE.chmod(0o600)` calls in `_scaffold_env()` and `_write_setup_complete()` are equally inert there — they don't raise, they just don't restrict anything.

The check is now POSIX-only. I did **not** try to substitute an ACL check via `icacls`; that's a bigger change and I'd rather not guess at what you'd want. The trade-off is explicit: Windows users get no permissions warning at all, rather than one that always fires and gives advice that cannot work.

## 2. `_frame_lines()` in the test suite only matches POSIX separators

```python
if "/frames/frame_" in line and "(t=" in line
```

The report prints native paths, so on Windows every frame line reads `...\frames\frame_0001.jpg` and the helper counts **zero**. `test_dedup_collapses_static_by_default` and `test_no_dedup_preserves_static_frames` failed on runs that had extracted and deduplicated frames perfectly well — the assertion was measuring the path separator, not the behaviour under test.

Now matches either separator.

## Result

Windows 10, Python 3.13.15, ffmpeg 9.0.1 (Gyan), yt-dlp 2026.08.19:

| | Result |
|---|---|
| `main` | 22 failed, 49 passed |
| \#186 alone | 3 failed, 68 passed |
| this branch | **0 failed, 71 passed** |

## Note on stacking

This branch is cut from `fix/ffmpeg-9-fps-mode` (#186), so that commit shows up here too. #186 is what makes frames get produced at all on ffmpeg 8+; without it the two dedup tests fail for a different reason and this fix can't be observed. Merge #186 first and this reduces to the single commit above, or squash them together — whichever you prefer.

My other open PR, #187, is independent of both.
