### PR TITLE
Fix frame extraction on ffmpeg 9: replace removed -vsync with -fps_mode

### DIFF
--- a/skills/watch/scripts/frames.py
+++ b/skills/watch/scripts/frames.py
@@ -253,7 +253,7 @@ def extract_scene_candidates(
     cmd += [
         "-i", str(Path(video_path).resolve()),
         "-vf", vf,
-        "-vsync", "vfr",
+        "-fps_mode", "vfr",
     ]
     if max_frames is not None:
         cmd += ["-frames:v", str(max_frames)]
@@ -612,7 +612,7 @@ def extract_keyframes(
         "-skip_frame", "nokey",
         "-i", str(Path(video_path).resolve()),
         "-vf", f"{_scale_filter(resolution)},showinfo",
-        "-vsync", "vfr",
+        "-fps_mode", "vfr",
         "-q:v", "4",
         output_pattern,
     ]


### PR DESCRIPTION
## Problem

ffmpeg 9.x removed the `-vsync` option. Both extraction paths in `frames.py` still pass it, so every frame extraction aborts:

```
ffmpeg scene extraction failed: Unrecognized option 'vsync'.
Error splitting the argument list: Option not found
```

`/watch` gets as far as downloading the video, then fails with zero frames.

## Fix

`-vsync vfr` → `-fps_mode vfr` at both call sites. `-fps_mode` is the documented replacement and has been supported since ffmpeg 5.x, so older builds keep working — no version detection needed.

## Verification

Windows 10, Python 3.14, ffmpeg 9.0.1 (Gyan build):

- Before: hard failure, 0 frames on a 19s clip.
- After: 19/19 frames extracted; focused mode (`--start`/`--end`) and dedup both behave as expected.

Test suite on this environment goes from **22 failed / 49 passed** to **3 failed / 68 passed**. The 3 remaining failures are pre-existing and unrelated to this change (the Windows-only test-helper path handling and POSIX permission check covered by #189 / #191).

## Note

This duplicates several open PRs (#198, #197, #194, #188, #186, #183, #181, #177, #172, #171, #168, #166, #162) and issues (#126 onwards) — the fix is uncontroversial and the same two lines everywhere. Happy to close this in favour of whichever one you prefer to merge; opening it mainly to add the ffmpeg 9.0.1 test-suite numbers above as evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)