### PR TITLE
Fix UnicodeEncodeError on Windows cp1252 consoles by forcing UTF-8 stdio

### DIFF
--- a/skills/watch/scripts/setup.py
+++ b/skills/watch/scripts/setup.py
@@ -27,6 +27,22 @@ import sys
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _force_utf8_stdio() -> None:
+    """Keep the report printable on Windows consoles that default to cp1252.
+
+    The report uses non-ASCII characters (arrows, ellipses, em dashes), and any
+    of them raises UnicodeEncodeError under the legacy code page. Reconfiguring
+    to UTF-8 with errors="replace" keeps output readable instead of aborting.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8", errors="replace")
+
+
+_force_utf8_stdio()
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 from config import get_config  # noqa: E402

--- a/skills/watch/scripts/watch.py
+++ b/skills/watch/scripts/watch.py
@@ -13,6 +13,22 @@ from pathlib import Path
 
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
+
+
+def _force_utf8_stdio() -> None:
+    """Keep the report printable on Windows consoles that default to cp1252.
+
+    The report uses non-ASCII characters (arrows, ellipses, em dashes), and any
+    of them raises UnicodeEncodeError under the legacy code page. Reconfiguring
+    to UTF-8 with errors="replace" keeps output readable instead of aborting.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8", errors="replace")
+
+
+_force_utf8_stdio()
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from config import frame_cap, get_config  # noqa: E402


### PR DESCRIPTION
## Problem

The report prints non-ASCII characters — the focus-range arrow (`→`), the ellipses in progress lines (`…`), the em dash in the transcript notice. On a Windows console using the legacy cp1252 code page, printing any of them aborts the run:

```
File "scripts/watch.py", line 280, in main
    f"- **Focus range:** {format_time(effective_start)} \u2192 ..."
UnicodeEncodeError: 'charmap' codec can't encode character '\u2192' in position 25
```

This is particularly wasteful because it fires *after* the download and frame extraction have completed — the work is done, and then the output is thrown away. Every `--start`/`--end` run on an affected console hits it.

The same encoding mismatch also garbles the progress lines even when they don't crash: `[watch] using local file…` renders as `[watch] using local file?`.

## Fix

Reconfigure stdout/stderr to UTF-8 with `errors="replace"` at entry in the two user-invoked scripts (`watch.py`, `setup.py`). `reconfigure` is looked up with `getattr` so redirected or wrapped streams that lack it are left alone.

`errors="replace"` rather than a hard UTF-8 assumption: if a console genuinely cannot render a character, a replacement glyph is a better outcome than losing the entire report.

## Verification

Windows 10, Python 3.14, cp1252 console, `PYTHONIOENCODING` unset:

- Before: traceback on any `--start`/`--end` run.
- After: clean report, `- **Focus range:** 02:00 → 02:20 (20.0s)`, and the progress-line ellipses render correctly.

Test suite unchanged at **3 failed / 68 passed** — no regression (those 3 are pre-existing Windows test-harness failures, see #189 / #191).

## Note

Overlaps with #192 and the Windows portions of #168 / #159. This one is scoped to just the encoding fix, so it should be safe to merge alongside or instead of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)