### PR TITLE
Frame-coverage fixes and an on-device Whisper fallback

### DIFF
--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: watch
 version: "0.2.0"
-description: Watch a video (URL or local path). Downloads with yt-dlp, extracts auto-scaled frames with ffmpeg, pulls the transcript from captions (or Whisper API fallback), and hands the result to Claude so it can answer questions about what's in the video.
+description: Watch a video (URL or local path). Downloads with yt-dlp, extracts auto-scaled frames with ffmpeg, pulls the transcript from captions (then a Whisper fallback — cloud API if a key is set, else local faster-whisper), and hands the result to Claude so it can answer questions about what's in the video.
 argument-hint: "<video-url-or-path> [question]"
 allowed-tools: Bash, Read, AskUserQuestion
 homepage: https://github.com/bradautomates/claude-video
@@ -13,7 +13,7 @@ user-invocable: true
 
 # /watch
 
-You don't have a video input; this skill gives you one. A Python script gets captions first, optionally downloads the video, extracts frames as JPEGs (scene-aware, or fast keyframes at `efficient` detail), gets a timestamped transcript (native captions first, then Whisper API as fallback), and prints frame paths. You then `Read` each frame path to see the images and combine them with the transcript to answer the user.
+You don't have a video input; this skill gives you one. A Python script gets captions first, optionally downloads the video, extracts frames as JPEGs (scene-aware, or fast keyframes at `efficient` detail), gets a timestamped transcript (native captions first, then a Whisper fallback — cloud API if a key is set, otherwise on-device faster-whisper), and prints frame paths. You then `Read` each frame path to see the images and combine them with the transcript to answer the user.
 
 ## Resolve `SKILL_DIR` (do this before any command)
 
@@ -70,7 +70,7 @@ On non-zero exit, follow the table:
 | Exit | Meaning | Action |
 |------|---------|--------|
 | `2` | Missing binaries (`ffmpeg` / `ffprobe` / `yt-dlp`) | Run installer |
-| `3` | Genuine first run with no Whisper API key | Run installer to scaffold `.env`, then encourage a key (the user may decline — proceed with `--no-whisper`) |
+| `3` | Genuine first run with no Whisper API key | Run installer to scaffold `.env`, then encourage a key (the user may decline — the script then falls back to local faster-whisper if installed, else frames-only) |
 | `4` | Both missing | Run installer, then encourage a key |
 
 Exit `3` only fires before the user has completed setup. Once `SETUP_COMPLETE=true` is written, a keyless install returns exit 0 and is never nagged again.
@@ -83,7 +83,7 @@ python3 "${SKILL_DIR}/scripts/setup.py"
 
 On macOS with Homebrew, it auto-installs `ffmpeg` and `yt-dlp`. On Linux/Windows, it prints the exact install commands for the user to run. It scaffolds `~/.config/watch/.env` with commented placeholders and default watch settings at `0600` perms.
 
-**If an API key is still missing after install:** use `AskUserQuestion` to ask the user whether they have a Groq API key (preferred — cheaper, faster) or an OpenAI key. Then write it into `~/.config/watch/.env` — set the matching `GROQ_API_KEY=...` or `OPENAI_API_KEY=...` line. If they don't want to set up Whisper, proceed with `--no-whisper` and tell them videos without native captions will come back frames-only.
+**If an API key is still missing after install:** use `AskUserQuestion` to ask the user whether they have a Groq API key (preferred — cheaper, faster) or an OpenAI key. Then write it into `~/.config/watch/.env` — set the matching `GROQ_API_KEY=...` or `OPENAI_API_KEY=...` line. If they don't want a cloud key, the script automatically falls back to **local faster-whisper** (on-device, no key, needs `pip install faster-whisper`) for videos without native captions — audio never leaves the machine. Only if faster-whisper isn't installed (or they pass `--no-whisper`) do such videos come back frames-only; mention that when relevant.
 
 **First-run watch preference:** after the installer has scaffolded `~/.config/watch/.env`, use `AskUserQuestion` to ask one question:
 
@@ -148,7 +148,7 @@ Optional flags:
 - `--fps F` — override auto-fps (clamped to 2 fps max)
 - `--out-dir DIR` — keep working files somewhere specific (default: an auto-generated tmp dir)
 - `--whisper groq|openai` — force a specific Whisper backend (default: prefer Groq if both keys exist)
-- `--no-whisper` — disable the Whisper fallback entirely (frames-only if no captions)
+- `--no-whisper` — disable the Whisper fallback entirely, both cloud and local (frames-only if no captions)
 - `--no-dedup` — keep near-duplicate frames. By default a frame-delta pass drops frames that are visually near-identical to the previous kept one (held slides, static screen recordings, paused video) so the frame budget goes to distinct content; the report's **Frames** line notes how many were dropped. Pass this only if the user needs every sampled frame (e.g. judging subtle frame-to-frame motion).
 
 ### Focusing on a section (higher frame rate)
@@ -184,7 +184,7 @@ python3 "${SKILL_DIR}/scripts/watch.py" "$URL" --start 1:12:00
 
 **Step 4 — answer the user.** You now have two streams of evidence:
 - **Frames** — what's on screen at each timestamp
-- **Transcript** — what's said at each timestamp. The report's header shows the source (`captions` = yt-dlp pulled native subs; `whisper (groq)` or `whisper (openai)` = transcribed by API).
+- **Transcript** — what's said at each timestamp. The report's header shows the source: `captions` = yt-dlp pulled native subs; `whisper (groq)` or `whisper (openai)` = transcribed by cloud API; `faster-whisper (large-v3)` = transcribed on-device (no key).
 
 If the user asked a specific question, answer it directly citing timestamps. If they didn't ask anything, summarize what happens in the video — structure, key moments, notable visuals, spoken content.
 
@@ -220,19 +220,20 @@ Behavior:
 
 ## Transcription
 
-The script gets a timestamped transcript in one of two ways:
+The script gets a timestamped transcript in one of three ways, tried in this order:
 
 1. **Native captions (free, preferred).** yt-dlp pulls manual or auto-generated subtitles from the source platform if available.
-2. **Whisper API fallback.** If no captions came back (or the source is a local file), the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever Whisper API has a key configured:
+2. **Cloud Whisper API.** If no captions came back (or the source is a local file) **and a cloud key is configured**, the script extracts audio (`ffmpeg -vn -ac 1 -ar 16000 -b:a 64k`, ~0.5 MB/min) and uploads it to whichever Whisper API has a key:
    - **Groq** — `whisper-large-v3`. Preferred default: cheaper, faster. Get a key at console.groq.com/keys.
    - **OpenAI** — `whisper-1`. Fallback. Get a key at platform.openai.com/api-keys.
+3. **Local faster-whisper (on-device, no key).** If no captions came back **and no cloud key is set**, the script transcribes locally with **faster-whisper (CTranslate2), `large-v3` model, `device="auto"` (CUDA if present, else CPU), `compute_type="int8"`** — no torch or GPU required. The report labels the source `faster-whisper (large-v3)`. Requires `pip install faster-whisper` (imported lazily; the first run downloads the model). Override the model with `WATCH_FW_MODEL` (e.g. `WATCH_FW_MODEL=small` for speed on a slow CPU).
 
-Both keys live in `~/.config/watch/.env`. The script prefers Groq when both are set; override with `--whisper openai` to force OpenAI. Use `--no-whisper` to skip the fallback entirely.
+Precedence detail: the cloud path and the local path are **either/or on whether a cloud key exists**, not sequential retries — if a cloud key is set, cloud Whisper is used and a cloud *failure* does not fall through to local (it reports no transcript). Local faster-whisper fires only when no cloud key is configured. Cloud keys live in `~/.config/watch/.env`; the script prefers Groq when both are set, override with `--whisper openai`. Use `--no-whisper` to skip the Whisper fallback entirely (both cloud and local).
 
 ## Failure modes and handling
 
 - **Setup preflight failed** → run `python3 "${SKILL_DIR}/scripts/setup.py"` (auto-installs ffmpeg/yt-dlp via brew on macOS, scaffolds the `.env`). For API key, ask the user via `AskUserQuestion` and write it to `~/.config/watch/.env`.
-- **No transcript available** → captions missing AND (no Whisper key OR Whisper API failed). Script prints a hint pointing to setup. Proceed frames-only and tell the user.
+- **No transcript available** → captions missing AND one of: a cloud key is set but the API failed; no cloud key and local faster-whisper isn't installed or failed; or `--no-whisper` was passed. The script prints a hint (for the keyless case, `pip install faster-whisper` or run setup for a cloud key). Proceed frames-only and tell the user.
 - **Long video warning printed** → acknowledge it in your answer. Offer to re-run focused on a specific section via `--start`/`--end` rather than a sparse full-video scan.
 - **Download fails** → yt-dlp's error goes to stderr. If it's a login-required or region-locked video, tell the user plainly; do not keep retrying.
 - **Whisper request fails** → the error is printed to stderr (likely: invalid key or rate limit). Audio over the API's 25 MB upload cap is split into chunks and transcribed automatically, so length alone won't fail it; if some chunks fail the transcript is partial and the dropped chunks are noted on stderr. The report will say "none available" only if every chunk fails. You can retry with `--whisper openai` if Groq failed (or vice versa).
@@ -253,16 +254,17 @@ If you already watched a video this session and the user asks a follow-up, do **
 - Runs `ffmpeg` / `ffprobe` locally to extract frames as JPEGs and, when Whisper is needed, a mono 16 kHz audio clip
 - Sends the extracted audio clip to Groq's Whisper API (`api.groq.com/openai/v1/audio/transcriptions`) when `GROQ_API_KEY` is set (preferred — cheaper, faster)
 - Sends the extracted audio clip to OpenAI's audio transcription API (`api.openai.com/v1/audio/transcriptions`) when `OPENAI_API_KEY` is set and Groq is not, or when `--whisper openai` is forced
+- Transcribes **on-device with faster-whisper** (no network) when no cloud key is set — audio never leaves the machine; the first such run downloads the `large-v3` model to the local faster-whisper cache
 - Writes the downloaded video, frames, audio, and an intermediate transcript to a working directory under the system temp dir (or `--out-dir` if specified) so Claude can `Read` them
 - Reads / creates `~/.config/watch/.env` (mode `0600`) to store the Whisper API key(s) and a `SETUP_COMPLETE` marker. As a fallback, also reads `.env` in the current working directory
 
 **What this skill does NOT do:**
-- Does not upload the video itself to any API — only the extracted audio goes out, and only when native captions are missing AND Whisper is not disabled with `--no-whisper`
+- Does not upload the video itself to any API — only the extracted audio goes out, and only on the **cloud** Whisper path (native captions missing, a cloud key set, and `--no-whisper` not passed). When it falls back to local faster-whisper, nothing is sent anywhere
 - Does not access any platform account (no login, no session cookies, no posting) — yt-dlp only ever requests public data
 - Does not share API keys between providers (Groq key only goes to `api.groq.com`, OpenAI key only goes to `api.openai.com`)
 - Does not log, cache, or write API keys to stdout, stderr, or output files
 - Does not persist anything outside the working directory and `~/.config/watch/.env` — clean up the working directory when you're done (Step 5)
 
-**Bundled scripts:** `scripts/watch.py` (entry point), `scripts/download.py` (yt-dlp wrapper), `scripts/frames.py` (ffmpeg frame extraction), `scripts/transcribe.py` (caption selection + Whisper orchestration), `scripts/whisper.py` (Groq / OpenAI clients), `scripts/setup.py` (preflight + installer)
+**Bundled scripts:** `scripts/watch.py` (entry point), `scripts/download.py` (yt-dlp wrapper), `scripts/frames.py` (ffmpeg frame extraction), `scripts/transcribe.py` (caption selection + Whisper orchestration), `scripts/whisper.py` (Groq / OpenAI cloud clients), `scripts/local_whisper.py` (on-device faster-whisper fallback), `scripts/setup.py` (preflight + installer)
 
 Review scripts before first use to verify behavior.

--- a/skills/watch/scripts/frames.py
+++ b/skills/watch/scripts/frames.py
@@ -179,6 +179,22 @@ def extract(
     if shutil.which("ffmpeg") is None:
         raise SystemExit("ffmpeg is not installed. Install with: brew install ffmpeg")
 
+    # ponytail: `fps` and `-frames:v max_frames` together only cover
+    # max_frames/fps seconds — ffmpeg stops decoding there, so a cap smaller than
+    # fps*duration spends the whole budget at the head of the range and leaves the
+    # tail unwatched. Lower fps instead so the budget spans the requested range.
+    # Costs one ffprobe only when the range has no explicit end.
+    if fps > 0 and max_frames:
+        span_end = end_seconds if end_seconds is not None else get_metadata(video_path)["duration_seconds"]
+        span = max(0.0, span_end - (start_seconds or 0.0))
+        if span > 0 and max_frames < int(round(fps * span)):
+            fps = max_frames / span
+            print(
+                f"[watch] fps lowered to {fps:.4f} so {max_frames} frames span the full "
+                f"{span:.0f}s (the requested fps would have covered only the opening seconds)",
+                file=sys.stderr,
+            )
+
     out_dir.mkdir(parents=True, exist_ok=True)
     for existing in out_dir.glob("frame_*.jpg"):
         existing.unlink()

--- a/skills/watch/scripts/frames.py
+++ b/skills/watch/scripts/frames.py
@@ -292,6 +292,40 @@ def _even_indices(count: int, n: int) -> list[int]:
     return [round(i * (count - 1) / (n - 1)) for i in range(n)]
 
 
+def _even_time_indices(times: list[float], n: int) -> list[int]:
+    """Indices of ``n`` candidates spread evenly over the *timeline* (first and
+    last always kept), each interior slot taking the candidate nearest its
+    evenly-spaced target time.
+
+    Index-spacing hands a cluster its share of the budget: 36 keyframes packed
+    into 6% of a video keep ~90% of the slots and the other 94% of the runtime
+    gets what's left. Spacing by timestamp gives every stretch of runtime the
+    same shot at a frame. Degenerate timelines (all one instant) fall back to
+    index-spacing.
+
+    ponytail: O(n * len(times)) nearest-search, fine for the ~10^3 frames these
+    engines produce; sort the targets and merge if that ever stops being true.
+    """
+    count = len(times)
+    if n >= count:
+        return list(range(count))
+    if n <= 1:
+        return [0]
+
+    span = times[-1] - times[0]
+    if span <= 0:
+        return _even_indices(count, n)
+
+    chosen = {0, count - 1}
+    for i in range(1, n - 1):
+        target = times[0] + span * i / (n - 1)
+        chosen.add(min(
+            (j for j in range(1, count - 1) if j not in chosen),
+            key=lambda j: (abs(times[j] - target), j),
+        ))
+    return sorted(chosen)
+
+
 def parse_timestamps(value: str | None) -> list[float]:
     """Parse a comma-separated list of times (SS, MM:SS, HH:MM:SS) into a
     sorted, de-duplicated list of seconds. Empty/blank tokens are skipped;
@@ -352,7 +386,9 @@ def extract_at_timestamps(
     dropped = len(requested) - len(in_window)
 
     if max_frames is not None and len(in_window) > max_frames:
-        points = [in_window[i] for i in _even_indices(len(in_window), max_frames)]
+        # in_window is already sorted times, so thin it the same way the frame
+        # engines do: by timestamp, not by position in the list.
+        points = [in_window[i] for i in _even_time_indices(in_window, max_frames)]
     else:
         points = in_window
 
@@ -391,14 +427,17 @@ def extract_at_timestamps(
 
 
 def _even_sample(candidates: list[dict], n: int) -> list[dict]:
-    """Pick ``n`` evenly-spaced candidates (always including first and last),
-    delete the JPEGs we drop, and reindex the survivors 0..len-1.
+    """Pick ``n`` candidates evenly spaced *in time* (always including first and
+    last), delete the JPEGs we drop, and reindex the survivors 0..len-1.
 
     Shared by every capped engine so all detail modes sample the same way:
     detect all candidates across the full range, then thin down to the cap.
     ``n >= len(candidates)`` keeps everything (the uncapped / under-cap case).
+    Spacing is by timestamp, not position in the list, so a burst of cuts in a
+    short stretch cannot eat the budget and leave the rest of the video bare.
     """
-    selected = [candidates[i] for i in _even_indices(len(candidates), n)]
+    times = [cand["timestamp_seconds"] for cand in candidates]
+    selected = [candidates[i] for i in _even_time_indices(times, n)]
 
     keep_paths = {sel["path"] for sel in selected}
     for cand in candidates:

--- a/skills/watch/scripts/frames.py
+++ b/skills/watch/scripts/frames.py
@@ -9,6 +9,7 @@ zooming in for detail).
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -16,7 +17,14 @@ import sys
 from pathlib import Path
 
 
-MAX_FPS = 2.0
+# ponytail: 2.0 is the sane default ceiling, not a law of nature — a fight scene or
+# any fast choreography needs more. Raising it changes nothing on its own: auto_fps and
+# auto_fps_focus target a frame *budget*, so the ceiling only ever binds an explicit
+# --fps. Pair it with --start/--end and --max-frames on a short range:
+#   WATCH_MAX_FPS=24 watch.py clip.mp4 --start 1:10 --end 1:40 --fps 24 --max-frames 720
+# Cost is the real ceiling: ~200 tokens per 512px frame, so 24fps is affordable for
+# tens of seconds, not minutes.
+MAX_FPS = float(os.environ.get("WATCH_MAX_FPS", "2.0"))
 SCENE_THRESHOLD = 0.20
 # Keep scene-detection results once we have at least this many distinct shots.
 # Below this the video is effectively static (screen recording, talking head),

--- a/skills/watch/scripts/local_whisper.py
+++ b/skills/watch/scripts/local_whisper.py
@@ -50,16 +50,22 @@ def transcribe_video_local(
     model = _get_model(model_name)
     # ponytail: temperature=0.0 alone + condition_on_previous_text (the default True)
     # makes whisper loop — it repeats one token or sentence from some point to the end
-    # of the file and the tail of the transcript is silently destroyed. These three
-    # settings are the fix: no conditioning on prior text, VAD to drop silence, and a
-    # temperature ladder so a degenerate decode is retried instead of accepted.
+    # of the file and the tail of the transcript is silently destroyed. These two
+    # settings are the fix: no conditioning on prior text, and a temperature ladder so
+    # a degenerate decode is retried instead of accepted.
+    #
+    # vad_filter is deliberately OFF. It looks like a free win and is not: on a
+    # 114-minute film it cut the last 26 minutes from 323 segments to 43 and dropped
+    # 1:33:02-1:43:16 entirely, and the same audio truncated at a different point when
+    # passed whole vs. sliced — so the loss scales with input length. It trades a loud
+    # failure (looping) for a silent one (a tail that just isn't there), which is worse
+    # because nothing in the output says it happened. Do not re-enable it as a
+    # denoising tweak without re-measuring segment counts on a long file.
     segments_iter, _info = model.transcribe(
         str(audio_path.resolve()),
         beam_size=5,
         condition_on_previous_text=False,
         temperature=[0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
-        vad_filter=True,
-        vad_parameters=dict(min_silence_duration_ms=500),
     )
 
     out: list[dict] = []

--- a/skills/watch/scripts/local_whisper.py
+++ b/skills/watch/scripts/local_whisper.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Local Whisper fallback via faster-whisper (CTranslate2) — no API key needed.
+
+Kicks in when no cloud (Groq/OpenAI) key is configured. Reuses whisper.extract_audio
+for the same ffmpeg audio extraction, then transcribes on-device with
+faster-whisper large-v3. Returns {start, end, text} segments identical in shape to
+the cloud path, so filter_range / format_transcript downstream don't care.
+
+Requires `pip install faster-whisper` (imports lazily, only when actually used).
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from whisper import extract_audio  # same ffmpeg mono-16k extraction as the cloud path
+
+# ponytail: large-v3 default (the "v3" model); override with WATCH_FW_MODEL=small
+# for speed on a slow CPU. int8 keeps it torch-free; bump to float16 if on GPU.
+DEFAULT_MODEL = os.environ.get("WATCH_FW_MODEL", "large-v3")
+
+_model_cache: dict[str, object] = {}
+
+
+def _get_model(name: str):
+    from faster_whisper import WhisperModel  # heavy import — only when transcribing
+
+    if name not in _model_cache:
+        # device="auto" uses CUDA if present else CPU; int8 needs neither torch nor GPU.
+        _model_cache[name] = WhisperModel(name, device="auto", compute_type="int8")
+    return _model_cache[name]
+
+
+def transcribe_video_local(
+    video_path: str,
+    audio_out: Path,
+    model_name: str | None = None,
+) -> tuple[list[dict], str]:
+    """Extract audio → transcribe locally. Returns (segments, backend_label)."""
+    model_name = model_name or DEFAULT_MODEL
+    print(f"[watch] extracting audio for local faster-whisper ({model_name})…", file=sys.stderr)
+    audio_path = extract_audio(video_path, audio_out)
+
+    print(
+        f"[watch] transcribing locally with faster-whisper {model_name} "
+        "(first run downloads the model)…",
+        file=sys.stderr,
+    )
+    model = _get_model(model_name)
+    # ponytail: temperature=0.0 alone + condition_on_previous_text (the default True)
+    # makes whisper loop — it repeats one token or sentence from some point to the end
+    # of the file and the tail of the transcript is silently destroyed. These three
+    # settings are the fix: no conditioning on prior text, VAD to drop silence, and a
+    # temperature ladder so a degenerate decode is retried instead of accepted.
+    segments_iter, _info = model.transcribe(
+        str(audio_path.resolve()),
+        beam_size=5,
+        condition_on_previous_text=False,
+        temperature=[0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+        vad_filter=True,
+        vad_parameters=dict(min_silence_duration_ms=500),
+    )
+
+    out: list[dict] = []
+    for seg in segments_iter:
+        text = (seg.text or "").strip()
+        if text:
+            out.append({"start": round(seg.start, 2), "end": round(seg.end, 2), "text": text})
+
+    if not out:
+        raise SystemExit("Local faster-whisper returned no transcript segments")
+
+    print(f"[watch] transcribed {len(out)} segments via faster-whisper {model_name}", file=sys.stderr)
+    return out, f"faster-whisper ({model_name})"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: local_whisper.py <video-path> [audio-out.mp3] [model]", file=sys.stderr)
+        raise SystemExit(2)
+    import json
+
+    video = sys.argv[1]
+    audio_out = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("audio.mp3")
+    model = sys.argv[3] if len(sys.argv) > 3 else None
+    segs, backend = transcribe_video_local(video, audio_out, model)
+    print(json.dumps({"backend": backend, "segments": segs}, indent=2))

--- a/skills/watch/scripts/local_whisper.py
+++ b/skills/watch/scripts/local_whisper.py
@@ -20,6 +20,21 @@ from whisper import extract_audio  # same ffmpeg mono-16k extraction as the clou
 # for speed on a slow CPU. int8 keeps it torch-free; bump to float16 if on GPU.
 DEFAULT_MODEL = os.environ.get("WATCH_FW_MODEL", "large-v3")
 
+# ponytail: whisper's own doubt cutoffs. Segments past either are MARKED, never
+# dropped — silently deleting weak audio is how the tail got eaten before, and a
+# reader can discount a marked line but not a removed one.
+#
+# Know what this does NOT do. It catches degraded audio, not invention. Measured on
+# the confabulated "yes, ma'am" passage that motivated it, the made-up lines scored
+# no_speech_prob 0.04 / avg_logprob -0.35 — more confident than the real dialogue
+# beside them, because these numbers describe decoding certainty, not truth, and a
+# fluent hallucination off a strong language prior decodes cleanly. The values are
+# also per decode window, not per segment: every line in that 30-second stretch
+# carried identical figures. Frames remain the only check on whether a quiet scene
+# said what the transcript claims.
+NO_SPEECH_MAX = 0.6
+AVG_LOGPROB_MIN = -1.0
+
 _model_cache: dict[str, object] = {}
 
 
@@ -54,13 +69,15 @@ def transcribe_video_local(
     # settings are the fix: no conditioning on prior text, and a temperature ladder so
     # a degenerate decode is retried instead of accepted.
     #
-    # vad_filter is deliberately OFF. It looks like a free win and is not: on a
-    # 114-minute film it cut the last 26 minutes from 323 segments to 43 and dropped
-    # 1:33:02-1:43:16 entirely, and the same audio truncated at a different point when
-    # passed whole vs. sliced — so the loss scales with input length. It trades a loud
-    # failure (looping) for a silent one (a tail that just isn't there), which is worse
-    # because nothing in the output says it happened. Do not re-enable it as a
-    # denoising tweak without re-measuring segment counts on a long file.
+    # vad_filter is deliberately OFF, and this is a trade rather than a free win.
+    # ON, a 114-minute film lost its last 21 minutes outright (785 segments vs 1543),
+    # and the truncation point moved depending on whether the audio was passed whole
+    # or sliced, so the loss scales with input length. OFF, silence reaches the model
+    # and it confabulates fluent dialogue over it — on that same film it invented a
+    # cleanup crew answering "yes, ma'am" over a scene where the frames show one
+    # person alone. Losing 21 real minutes is worse than gaining a few invented lines
+    # that the confidence marking below flags, so OFF stands. Do not flip it back
+    # without re-measuring segment counts on a long file.
     segments_iter, _info = model.transcribe(
         str(audio_path.resolve()),
         beam_size=5,
@@ -69,15 +86,28 @@ def transcribe_video_local(
     )
 
     out: list[dict] = []
+    n_unsure = 0
     for seg in segments_iter:
         text = (seg.text or "").strip()
-        if text:
-            out.append({"start": round(seg.start, 2), "end": round(seg.end, 2), "text": text})
+        if not text:
+            continue
+        record = {"start": round(seg.start, 2), "end": round(seg.end, 2), "text": text}
+        # Fail-open: a build that does not report these is treated as confident.
+        no_speech = getattr(seg, "no_speech_prob", 0.0)
+        avg_logprob = getattr(seg, "avg_logprob", 0.0)
+        if no_speech > NO_SPEECH_MAX or avg_logprob < AVG_LOGPROB_MIN:
+            record["uncertain"] = True
+            n_unsure += 1
+        out.append(record)
 
     if not out:
         raise SystemExit("Local faster-whisper returned no transcript segments")
 
-    print(f"[watch] transcribed {len(out)} segments via faster-whisper {model_name}", file=sys.stderr)
+    note = f", {n_unsure} low-confidence (marked [?])" if n_unsure else ""
+    print(
+        f"[watch] transcribed {len(out)} segments via faster-whisper {model_name}{note}",
+        file=sys.stderr,
+    )
     return out, f"faster-whisper ({model_name})"
 
 

--- a/skills/watch/scripts/transcribe.py
+++ b/skills/watch/scripts/transcribe.py
@@ -85,7 +85,9 @@ def format_transcript(segments: list[dict]) -> str:
     for seg in segments:
         start = int(seg["start"])
         stamp = f"[{start // 60:02d}:{start % 60:02d}]"
-        lines.append(f"{stamp} {seg['text']}")
+        # Local whisper flags segments it doubts; captions and the cloud path never do.
+        mark = " [?]" if seg.get("uncertain") else ""
+        lines.append(f"{stamp} {seg['text']}{mark}")
     return "\n".join(lines)
 
 

--- a/skills/watch/scripts/watch.py
+++ b/skills/watch/scripts/watch.py
@@ -26,6 +26,7 @@ from download import download, fetch_captions, is_url  # noqa: E402
 from frames import MAX_FPS, auto_fps, auto_fps_focus, extract_at_timestamps, extract_keyframes, extract_scene_or_uniform, format_time, get_metadata, merge_frames, parse_time, parse_timestamps  # noqa: E402
 from transcribe import filter_range, format_transcript, parse_vtt  # noqa: E402
 from whisper import load_api_key, transcribe_video  # noqa: E402
+from local_whisper import transcribe_video_local  # noqa: E402
 
 
 def main() -> int:
@@ -258,16 +259,24 @@ def main() -> int:
             except SystemExit as exc:
                 print(f"[watch] whisper fallback failed: {exc}", file=sys.stderr)
         else:
-            hint = (
-                f"--whisper {args.whisper} was set but the matching API key is missing"
-                if args.whisper else
-                "no subtitles and no Whisper API key found"
-            )
-            setup_py = SCRIPT_DIR / "setup.py"
-            print(
-                f"[watch] {hint} — run `python3 {setup_py}` to enable the Whisper fallback",
-                file=sys.stderr,
-            )
+            # No cloud key — fall back to local faster-whisper (no API key needed).
+            try:
+                all_segments, used_backend = transcribe_video_local(
+                    video_path,
+                    work / "audio.mp3",
+                )
+                transcript_segments = filter_range(all_segments, start_sec, end_sec) if focused else all_segments
+                transcript_text = format_transcript(transcript_segments)
+                transcript_source = used_backend
+            except SystemExit as exc:
+                print(f"[watch] local whisper fallback failed: {exc}", file=sys.stderr)
+            except Exception as exc:
+                setup_py = SCRIPT_DIR / "setup.py"
+                print(
+                    f"[watch] no cloud Whisper key and local faster-whisper unavailable ({exc}) — "
+                    f"`pip install faster-whisper` or run `python3 {setup_py}` for a cloud key",
+                    file=sys.stderr,
+                )
     elif not transcript_segments and video_path and not meta.get("has_audio"):
         print("[watch] no audio stream found — proceeding without transcription", file=sys.stderr)
 

--- a/skills/watch/scripts/watch.py
+++ b/skills/watch/scripts/watch.py
@@ -12,6 +12,12 @@ import tempfile
 from pathlib import Path
 
 
+# ponytail: Windows stdout defaults to cp1252, which cannot encode the report's
+# arrows or emoji from video.info.json — the run completes and then dies printing it.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 SCRIPT_DIR = Path(__file__).parent.resolve()
 sys.path.insert(0, str(SCRIPT_DIR))
 

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -84,3 +84,11 @@ def test_even_time_indices_spreads_over_clustered_candidates():
     assert frames._even_time_indices(times, 99) == list(range(len(times)))
     assert frames._even_time_indices(times, 1) == [0]
     assert frames._even_time_indices([5.0] * 10, 3) == [0, 4, 9]  # flat → index
+
+
+def test_extract_lowers_fps_so_cap_spans_the_range(cut_clip: Path, tmp_path: Path):
+    """4 frames at 2fps covers only the opening 2s of a 5.6s clip; the cap has
+    to stretch over the whole range instead of clumping at the head."""
+    out = frames.extract(str(cut_clip), tmp_path / "f", fps=2.0, max_frames=4)
+    assert len(out) == 4
+    assert out[-1]["timestamp_seconds"] > 3.0

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -68,3 +68,19 @@ def test_scene_fallback_on_static_clip(static_clip: Path, tmp_path: Path):
     )
     assert meta["engine"] == "uniform"
     assert meta["fallback"] is True
+
+
+def test_even_time_indices_spreads_over_clustered_candidates():
+    """36 of 40 candidates packed into the first 6% of a 100s clip: index
+    spacing keeps ~90% of the budget inside that 6%, time spacing must not."""
+    times = [i * 0.17 for i in range(36)] + [40.0, 60.0, 80.0, 100.0]
+
+    picked = [times[i] for i in frames._even_time_indices(times, 5)]
+    assert picked == sorted(picked)
+    assert picked[0] == times[0] and picked[-1] == times[-1]
+    assert sum(1 for t in picked if t <= 6.0) <= 2  # index spacing gives 4
+
+    # Contract kept from _even_indices.
+    assert frames._even_time_indices(times, 99) == list(range(len(times)))
+    assert frames._even_time_indices(times, 1) == [0]
+    assert frames._even_time_indices([5.0] * 10, 3) == [0, 4, 9]  # flat → index

--- a/tests/test_timestamps.py
+++ b/tests/test_timestamps.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 import frames
+import transcribe as frames_transcribe
 
 
 def test_parse_timestamps_mixed_formats():
@@ -85,3 +86,13 @@ def test_extract_at_timestamps_does_not_clobber_detail_frames(cut_clip: Path, tm
     cues, _ = frames.extract_at_timestamps(str(cut_clip), d, [1.0, 3.0])
     assert len(list(d.glob("frame_*.jpg"))) == len(scene)
     assert len(list(d.glob("cue_*.jpg"))) == len(cues)
+
+
+def test_format_transcript_marks_uncertain_segments():
+    """Local whisper flags segments it doubts; captions and the cloud path never do,
+    so an unflagged segment must render exactly as before."""
+    out = frames_transcribe.format_transcript([
+        {"start": 5.0, "end": 6.0, "text": "sure of this"},
+        {"start": 65.0, "end": 66.0, "text": "not sure of this", "uncertain": True},
+    ])
+    assert out.splitlines() == ["[00:05] sure of this", "[01:05] not sure of this [?]"]


### PR DESCRIPTION
Seven commits, each reviewable on its own. Three fix cases where the frame budget was spent in the wrong place; three add a keyless transcription path; one is a Windows crash.

### Frame coverage

**`_even_sample` spaced candidates by list index, not timestamp.** Every capped engine routes through it, so a cluster kept its proportional share of the budget: 36 keyframes packed into 6% of a video held ~90% of the slots and the other 94% of the runtime got what was left. `_even_time_indices` pins first and last, then gives each interior slot the candidate nearest its evenly-spaced target time. Degenerate timelines fall back to the old index spacing. Existing contracts unchanged — sorted, exactly `n`, reindexed `0..n-1`, spans first→last. The over-cap `--timestamps` cue path got the same treatment.

**`-vf fps=N` with `-frames:v max_frames` only covers `max_frames/N` seconds.** ffmpeg stops decoding at the cap, so any cap below `fps * duration` spent the whole budget at the head of the range: 4 frames at 2fps watched the first 2s of a 5.6s clip. Now fps is lowered to `max_frames/span`.

**`MAX_FPS` is overridable via `WATCH_MAX_FPS`.**

A related scene-detection coverage bug is in #210, separately.

### On-device Whisper fallback

A keyless install had no transcription path at all. Nothing about Whisper actually requires the network.

`local_whisper.py` transcribes on-device with faster-whisper (CTranslate2), `large-v3`, `device="auto"`, `compute_type="int8"` — no torch, no GPU, no key. It reuses `whisper.extract_audio` and returns `{start, end, text}` in the cloud path's shape, so `filter_range`/`format_transcript` are untouched. Lazy import. Precedence is either/or on whether a cloud key exists; `--no-whisper` disables both; audio never leaves the machine on the local path.

**`vad_filter` is deliberately off**, and it's the thing to review hardest, because I originally had it on and it was destroying transcripts. Full 114-minute film, `small` model, only the flag changed:

| | segments | last segment |
|---|---|---|
| `vad_filter=True` | 785 | 1:33:03 |
| `vad_filter=False` | **1543** | **1:53:44** |

VAD-on also dropped `1:33:02`–`1:43:16` outright, and the truncation point moved depending on whether the audio was passed whole or sliced, so the loss scales with input length.

**It is a trade, not a free win.** With VAD off, silence reaches the model and it confabulates. On that same film it invented a cleanup crew answering *"yes, ma'am"* over a scene the frames show as one person standing alone. Losing 21 real minutes is worse than gaining a few invented lines, so off stands — but the comment now says both halves.

**Low-confidence segments are marked, never dropped.** Whisper computes per-window doubt and we were discarding it; segments past its usual cutoffs now render `[?]`. Scope, measured rather than assumed: **this catches degraded audio, not invention.** I checked whether it would have caught the fabricated passage above — it would not. Those lines scored `no_speech_prob 0.04 / avg_logprob -0.35`, *more* confident than the real dialogue beside them, because the numbers describe decoding certainty rather than truth. They're also per decode window, not per segment. Both limits are in the code comment so nobody mistakes a clean transcript for a verified one.

### Windows

`watch.py` reconfigures stdout/stderr to UTF-8. Windows defaults to cp1252, so a run would extract every frame and then die with `UnicodeEncodeError` printing the report.

### Testing

Three tests added: `test_even_time_indices_spreads_over_clustered_candidates`, `test_extract_lowers_fps_so_cap_spans_the_range` (real fixture), and `test_format_transcript_marks_uncertain_segments`. Full suite on Windows: 3 failed / 71 passed, versus 3 failed / 68 passed on `main` — same three pre-existing failures, no regressions. #206 and #208 clear all three.

No unit test for the local whisper path: it needs `faster-whisper` installed and the module is a thin wrapper around one library call, so a mock would only assert I passed the arguments I passed. It was exercised end-to-end on a full-length feature instead, which is what surfaced the VAD problem and then the hallucination behind it.

https://claude.ai/code/session_019uv6XEHwsdyLLLuHkZTThd
