### PR TITLE
Make Windows file-permission handling honest instead of a no-op

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,4 +47,4 @@ bash skills/watch/scripts/build-skill.sh   # → dist/watch.skill
 
 - Keep the version in sync across `skills/watch/SKILL.md` (frontmatter), `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json` when cutting a release.
 - Releasing: tag `vX.Y.Z` and push the tag; `.github/workflows/release.yml` builds `dist/watch.skill` and attaches it to the GitHub release.
-- Never commit real API keys or `.env` contents; keys live in `~/.config/watch/.env` (mode `0600`) at runtime.
+- Never commit real API keys or `.env` contents; keys live in `~/.config/watch/.env` at runtime (mode `0600` on macOS/Linux; inherited user-profile ACL on Windows).

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ On the first `/watch` call, the skill runs `scripts/setup.py --check`. If `ffmpe
 - **macOS** — auto-runs `brew install ffmpeg yt-dlp`.
 - **Linux** — prints the exact `apt` / `dnf` / `pipx` commands.
 - **Windows** — prints the `winget` / `pip` commands.
-- **API key** — scaffolds `~/.config/watch/.env` (mode `0600`) with commented placeholders for `GROQ_API_KEY` (preferred) and `OPENAI_API_KEY`.
+- **API key** — scaffolds `~/.config/watch/.env` with commented placeholders for `GROQ_API_KEY` (preferred) and `OPENAI_API_KEY`. Restricted to mode `0600` on macOS/Linux; on Windows it keeps the inherited profile ACL (you, SYSTEM, Administrators) — POSIX modes are not settable there.
 
 After setup, preflight is silent and `/watch` just works. The check is a sub-100ms lookup, so it doesn't slow you down on subsequent runs.
 

--- a/hooks/scripts/check-setup.sh
+++ b/hooks/scripts/check-setup.sh
@@ -7,7 +7,13 @@ set -euo pipefail
 CONFIG_FILE="$HOME/.config/watch/.env"
 
 # Warn if the secrets file has loose permissions.
-if [[ -f "$CONFIG_FILE" ]]; then
+# ponytail: skipped on Git Bash / MSYS / Cygwin. stat there synthesizes a mode
+# (644) with no relation to the real NTFS ACL, and `chmod 600` is a silent no-op,
+# so the check could only ever nag every session with a fix that cannot work.
+# Windows access is governed by the ACL, owner-only by default under the profile.
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) IS_WINDOWS=1 ;; *) IS_WINDOWS="" ;; esac
+
+if [[ -f "$CONFIG_FILE" && -z "$IS_WINDOWS" ]]; then
   perms=$(stat -c '%a' "$CONFIG_FILE" 2>/dev/null || stat -f '%Lp' "$CONFIG_FILE" 2>/dev/null || echo "")
   if [[ -n "$perms" && "$perms" != "600" && "$perms" != "400" ]]; then
     echo "/watch: WARNING — $CONFIG_FILE has permissions $perms (should be 600)."

--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -81,7 +81,7 @@ The installer is idempotent — safe to re-run:
 python3 "${SKILL_DIR}/scripts/setup.py"
 ```
 
-On macOS with Homebrew, it auto-installs `ffmpeg` and `yt-dlp`. On Linux/Windows, it prints the exact install commands for the user to run. It scaffolds `~/.config/watch/.env` with commented placeholders and default watch settings at `0600` perms.
+On macOS with Homebrew, it auto-installs `ffmpeg` and `yt-dlp`. On Linux/Windows, it prints the exact install commands for the user to run. It scaffolds `~/.config/watch/.env` with commented placeholders and default watch settings, restricted to `0600` on macOS/Linux (on Windows the file keeps the inherited user-profile ACL — POSIX modes do not apply).
 
 **If an API key is still missing after install:** use `AskUserQuestion` to ask the user whether they have a Groq API key (preferred — cheaper, faster) or an OpenAI key. Then write it into `~/.config/watch/.env` — set the matching `GROQ_API_KEY=...` or `OPENAI_API_KEY=...` line. If they don't want to set up Whisper, proceed with `--no-whisper` and tell them videos without native captions will come back frames-only.
 
@@ -254,7 +254,7 @@ If you already watched a video this session and the user asks a follow-up, do **
 - Sends the extracted audio clip to Groq's Whisper API (`api.groq.com/openai/v1/audio/transcriptions`) when `GROQ_API_KEY` is set (preferred — cheaper, faster)
 - Sends the extracted audio clip to OpenAI's audio transcription API (`api.openai.com/v1/audio/transcriptions`) when `OPENAI_API_KEY` is set and Groq is not, or when `--whisper openai` is forced
 - Writes the downloaded video, frames, audio, and an intermediate transcript to a working directory under the system temp dir (or `--out-dir` if specified) so Claude can `Read` them
-- Reads / creates `~/.config/watch/.env` (mode `0600`) to store the Whisper API key(s) and a `SETUP_COMPLETE` marker. As a fallback, also reads `.env` in the current working directory
+- Reads / creates `~/.config/watch/.env` (mode `0600` on macOS/Linux; inherited user-profile ACL on Windows) to store the Whisper API key(s) and a `SETUP_COMPLETE` marker. As a fallback, also reads `.env` in the current working directory
 
 **What this skill does NOT do:**
 - Does not upload the video itself to any API — only the extracted audio goes out, and only when native captions are missing AND Whisper is not disabled with `--no-whisper`

--- a/skills/watch/scripts/setup.py
+++ b/skills/watch/scripts/setup.py
@@ -69,10 +69,24 @@ def _check_binaries() -> list[str]:
 
 _PERM_WARNED: set[str] = set()
 
+# ponytail: POSIX mode bits do not govern access on Windows and cannot be set
+# from Python — os.chmod there only toggles the read-only attribute, verified by
+# creating a file with and without chmod(0o600) and diffing icacls: identical,
+# both inheriting SYSTEM / Administrators / user. So the mode is neither
+# meaningful to read nor settable to write, and both halves are skipped below.
+_IS_WINDOWS = os.name == "nt"
+
 
 def _check_file_permissions(path: Path) -> None:
     """Warn to stderr (once per path per process) if a secrets file is
-    world/group readable."""
+    world/group readable.
+
+    No-op on Windows: st_mode there is synthesized from the read-only attribute,
+    so the group/other bits are always set and this would warn on every run with
+    a `chmod 600` fix that cannot change anything.
+    """
+    if _IS_WINDOWS:
+        return
     key = str(path)
     if key in _PERM_WARNED:
         return
@@ -126,16 +140,31 @@ def is_first_run() -> bool:
     return _read_env_key("SETUP_COMPLETE") != "true"
 
 
+def _restrict_config_file() -> None:
+    """Restrict .env to the owner where the platform supports it.
+
+    POSIX: mode 0600. Windows: nothing — the file keeps the ACL it inherits from
+    the user profile, which grants the user, SYSTEM and Administrators. That is
+    the normal posture for user secrets on Windows (an administrator can read
+    any file regardless), and no other ordinary user is granted access. Locking
+    it further would mean icacls /inheritance:r, which mostly breaks backup and
+    AV agents for no gain against an attacker who is already an admin.
+    """
+    if _IS_WINDOWS:
+        return
+    try:
+        CONFIG_FILE.chmod(0o600)
+    except OSError:
+        pass
+
+
 def _scaffold_env() -> bool:
     """Create ~/.config/watch/.env with placeholders if missing."""
     if CONFIG_FILE.exists():
         return False
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     CONFIG_FILE.write_text(ENV_TEMPLATE, encoding="utf-8")
-    try:
-        CONFIG_FILE.chmod(0o600)
-    except OSError:
-        pass
+    _restrict_config_file()
     return True
 
 
@@ -157,10 +186,7 @@ def _write_setup_complete() -> None:
         CONFIG_FILE.write_text(existing + "SETUP_COMPLETE=true\n", encoding="utf-8")
     else:
         CONFIG_FILE.write_text(ENV_TEMPLATE + "\nSETUP_COMPLETE=true\n", encoding="utf-8")
-    try:
-        CONFIG_FILE.chmod(0o600)
-    except OSError:
-        pass
+    _restrict_config_file()
 
 
 def _brew_pkg(missing: list[str]) -> list[str]:


### PR DESCRIPTION
Two commits, independent of #205. POSIX mode bits do not govern access on Windows and cannot be set from Python or Git Bash, but three places in the codebase acted as if they could.

### The session-start nag

`check-setup.sh` warns when `~/.config/watch/.env` isn't mode 600 and tells the user to run `chmod 600`. On Git Bash / MSYS / Cygwin both halves are broken: `stat -c '%a'` reports a synthesized `644` with no relation to the real NTFS ACL, and `chmod` is a silent no-op. Confirmed the round trip on Windows 11 / Git Bash — `chmod 600` then `stat` still reads `644`. Result: a `SessionStart` warning every single session, with a fix that provably cannot clear it.

### The same bug in Python

`setup.py` called `CONFIG_FILE.chmod(0o600)` after writing the secrets file, and `_check_file_permissions` warned when `st_mode & 0o044`. On Windows `os.chmod` only toggles the read-only attribute, and `st_mode` is synthesized from that same attribute — so the write was inert and the check always fired.

Verified rather than assumed: created two files in the same directory, one with `chmod(0o600)` and one without, and diffed `icacls`. Identical, both inheriting `SYSTEM` / `Administrators` / user.

### What Windows actually gives you

```
C:\Users\jorda\.config\watch   SYSTEM:(I)(F)  Administrators:(I)(F)  jorda:(I)(F)
```

The user, SYSTEM and Administrators — inherited from the user profile — and no other ordinary user. That is the normal posture for user secrets on Windows; an administrator can read any file regardless. So the practical guarantee `0600` was reaching for mostly holds, but the mechanism advertised isn't the one in play.

### The change

Restrict on POSIX, skip on Windows, and document what each platform actually gets. `README.md`, `SKILL.md` (both mentions) and `AGENTS.md` no longer claim a flat `0600`. The mode check still runs unchanged on `Linux` and `Darwin` — verified against `uname -s` values for all five platforms.

I stopped short of `icacls /inheritance:r /grant:r`, which would make literal owner-only true. It strips SYSTEM and Administrators, breaking backup and AV agents, and buys nothing against an attacker who is already an admin and can take ownership. The stopping point is named in a code comment so it reads as a decision rather than an oversight. Happy to add it if you'd rather have the strict version.

### Correction

An earlier revision of this description claimed owner-only was "the default for anything created under the user profile." That was wrong — the parent directories above show the default includes SYSTEM and Administrators. The one `.env` I first inspected had an explicit owner-only ACL set by something other than this tool, which is what misled me. The conclusion is unchanged; the reasoning is now accurate.

https://claude.ai/code/session_019uv6XEHwsdyLLLuHkZTThd
