### PR TITLE
Match frame report lines regardless of path separator

### DIFF
--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -70,7 +70,10 @@ def test_timestamps_with_transcript_detail_is_cue_only(cut_clip: Path):
 
 
 def _frame_lines(out: str) -> int:
-    return sum(1 for line in out.splitlines() if "/frames/frame_" in line and "(t=" in line)
+    # The report prints native paths, so frame lines carry backslashes on
+    # Windows and this counted zero of them. Normalize before matching.
+    lines = out.replace("\\", "/").splitlines()
+    return sum(1 for line in lines if "/frames/frame_" in line and "(t=" in line)
 
 
 def test_dedup_collapses_static_by_default(static_clip: Path):


### PR DESCRIPTION
One commit, test-only, independent of #205 and #206.

`_frame_lines` in `tests/test_watch.py` counts report lines containing `/frames/frame_`. The report prints native paths, so on Windows those lines read:

```
- `C:\Users\...\watch-efn6ellu\frames\frame_0001.jpg` (t=00:00, reason=uniform)
```

The helper matches none of them and returns 0, failing `test_dedup_collapses_static_by_default` and `test_no_dedup_preserves_static_frames` against entirely correct output. `watch.py` does collapse the static clip to exactly one frame line — I checked the raw report before touching anything. Both tests' other assertions (`"near-duplicate" in out` / `not in out`) passed throughout, which is what pointed at the helper rather than the product.

Normalize separators before matching. No production code touched.

### Suite status on Windows

For context, since the repo has no test CI and these were the only two failures I couldn't attribute to a real bug:

| branch | result |
|---|---|
| `main` | 3 failed, 68 passed |
| this branch | 1 failed, 70 passed |

The one remaining failure on `main` and here is `test_setup.py::test_keyless_completed_setup_proceeds_silently`, which #206 fixes — it's the Windows permission false-positive asserting its way into the suite. With #206 and this branch both applied the suite is green on Windows.

https://claude.ai/code/session_019uv6XEHwsdyLLLuHkZTThd
